### PR TITLE
fix(lile/studio): Snapshots tab renders daemon results

### DIFF
--- a/studio/frontend/src/features/lile/api/lile-client.ts
+++ b/studio/frontend/src/features/lile/api/lile-client.ts
@@ -47,7 +47,7 @@ export const lileClient = {
     }).then((r) => json<unknown>(r));
   },
   getSnapshots(): Promise<unknown> {
-    return fetch(`${BASE}/v1/state/snapshot/list`).then((r) => json<unknown>(r));
+    return fetch(`${BASE}/v1/state/snapshots`).then((r) => json<unknown>(r));
   },
   postSnapshot(name: string): Promise<unknown> {
     return fetch(`${BASE}/v1/state/snapshot/save`, {

--- a/studio/frontend/src/features/lile/components/snapshots-tab.test.tsx
+++ b/studio/frontend/src/features/lile/components/snapshots-tab.test.tsx
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { describe, it, expect, spyOn, beforeEach, afterEach } from "bun:test";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import { lileClient } from "../api/lile-client";
+import { SnapshotsTab } from "./snapshots-tab";
+
+describe("SnapshotsTab", () => {
+  beforeEach(() => {
+    cleanup();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders rows when the daemon returns {snapshots: string[]}", async () => {
+    // Shape that `SnapshotManager.list()` actually returns today:
+    // the route wraps `list[str]` in `{"snapshots": [...]}`.
+    const spy = spyOn(lileClient, "getSnapshots").mockImplementation(() =>
+      Promise.resolve({ snapshots: ["pre_reasoning_restart", "pre_streaming_restart"] }),
+    );
+
+    render(<SnapshotsTab />);
+
+    await waitFor(() => {
+      expect(screen.getByText("pre_reasoning_restart")).toBeTruthy();
+      expect(screen.getByText("pre_streaming_restart")).toBeTruthy();
+    });
+
+    expect(screen.queryByText(/no snapshots yet/i)).toBeNull();
+
+    spy.mockRestore();
+  });
+
+  it("still accepts {snapshots: SnapshotRow[]} shape for forward-compat", async () => {
+    const spy = spyOn(lileClient, "getSnapshots").mockImplementation(() =>
+      Promise.resolve({
+        snapshots: [
+          { name: "v1", created_at: "2026-04-17" },
+          { name: "v2" },
+        ],
+      }),
+    );
+
+    render(<SnapshotsTab />);
+
+    await waitFor(() => {
+      expect(screen.getByText("v1")).toBeTruthy();
+      expect(screen.getByText("v2")).toBeTruthy();
+      expect(screen.getByText("2026-04-17")).toBeTruthy();
+    });
+
+    spy.mockRestore();
+  });
+
+  it("shows empty state when the daemon returns an empty list", async () => {
+    const spy = spyOn(lileClient, "getSnapshots").mockImplementation(() =>
+      Promise.resolve({ snapshots: [] }),
+    );
+
+    render(<SnapshotsTab />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/no snapshots yet/i)).toBeTruthy();
+    });
+
+    spy.mockRestore();
+  });
+});
+
+describe("lileClient.getSnapshots URL", () => {
+  it("hits /api/lile/v1/state/snapshots (matches daemon route)", async () => {
+    const fetchSpy = spyOn(globalThis, "fetch").mockImplementation(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ snapshots: [] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      ),
+    );
+
+    await lileClient.getSnapshots();
+
+    expect(fetchSpy.mock.calls.length).toBeGreaterThanOrEqual(1);
+    const url = String(fetchSpy.mock.calls[0][0]);
+    expect(url).toBe("/api/lile/v1/state/snapshots");
+
+    fetchSpy.mockRestore();
+  });
+});

--- a/studio/frontend/src/features/lile/components/snapshots-tab.tsx
+++ b/studio/frontend/src/features/lile/components/snapshots-tab.tsx
@@ -19,13 +19,29 @@ import { useLileCapsuleStore } from "../stores/lile-capsule-store";
 
 type SnapshotRow = { name: string; created_at?: string };
 
-function normalizeSnapshots(result: unknown): SnapshotRow[] {
-  if (Array.isArray(result)) return result as SnapshotRow[];
-  if (result && typeof result === "object" && "snapshots" in result) {
-    const r = result as { snapshots?: unknown };
-    return Array.isArray(r.snapshots) ? (r.snapshots as SnapshotRow[]) : [];
+function toRow(item: unknown): SnapshotRow | null {
+  if (typeof item === "string") return { name: item };
+  if (item && typeof item === "object" && "name" in item) {
+    const o = item as { name: unknown; created_at?: unknown };
+    if (typeof o.name === "string") {
+      return {
+        name: o.name,
+        created_at: typeof o.created_at === "string" ? o.created_at : undefined,
+      };
+    }
   }
-  return [];
+  return null;
+}
+
+export function normalizeSnapshots(result: unknown): SnapshotRow[] {
+  const items = Array.isArray(result)
+    ? result
+    : result && typeof result === "object" && "snapshots" in result
+      ? Array.isArray((result as { snapshots?: unknown }).snapshots)
+        ? ((result as { snapshots: unknown[] }).snapshots)
+        : []
+      : [];
+  return items.map(toRow).filter((x): x is SnapshotRow => x !== null);
 }
 
 export function SnapshotsTab(): ReactElement {


### PR DESCRIPTION
## Summary

Repro (from %4 via PO):
- `curl http://127.0.0.1:8768/v1/state/snapshots` → `{"snapshots":["pre_reasoning_restart","pre_streaming_restart"]}`
- `curl http://127.0.0.1:8888/api/lile/v1/state/snapshots` → same (Studio proxy healthy)
- Studio UI on :5173 → **empty**

Root cause was entirely in the frontend — two compounding bugs:

1. **URL mismatch.** `lileClient.getSnapshots()` hit `/v1/state/snapshot/list`; the daemon exposes `/v1/state/snapshots` (`lile/server.py:249`). The proxy forwarded the 404.
2. **Shape mismatch.** Even with the right URL, `normalizeSnapshots` cast a bare `string[]` — which is what `SnapshotManager.list()` actually returns (`lile/snapshot.py:76-77`) — directly to `SnapshotRow[]`. `row.name` was `undefined`, so every cell rendered blank.

## Fix

- `api/lile-client.ts` — `getSnapshots()` now points at `/v1/state/snapshots`.
- `components/snapshots-tab.tsx` — `normalizeSnapshots` promoted to module export; handles `string[]`, `{name, created_at?}` objects, and bare `{snapshots: …}` wrappers in any combination.
- `components/snapshots-tab.test.tsx` — new; pins:
  - daemon's current `{snapshots: string[]}` wire shape
  - forward-compat `{snapshots: [{name, created_at}]}` shape (so we don't regress when the API grows metadata)
  - empty-list path
  - `lileClient.getSnapshots` request URL

## Verification

- `bun test src/features/lile` → **13/13 pass** (4 new in `snapshots-tab.test.tsx`, 9 pre-existing).
- Live check: ran a second vite on :5174 against this branch, clicked Snapshots tab with a headless browser — the table now renders:

```
Name	Created at
pre_reasoning_restart	—
pre_streaming_restart	—
```

(Screenshot pushed to show-me during development; attached below if I can inline it.)

## Non-goals

- Extending the daemon to ship richer per-snapshot metadata (`created_at`, `size`, `protected`). `SnapshotManager._dir(name)/manifest.json` has `created_at` today, but surfacing it is an API-shape change — flagged to %4 in advance; deferring until after the v0.2 release sweep lands.
- Snapshot LRU / rotation — tracked as #16.

## Test plan

- [x] Unit: `bun test src/features/lile/components/snapshots-tab.test.tsx` — 4/4 pass
- [x] Feature: `bun test src/features/lile` — 13/13 pass
- [x] Visual: Snapshots tab populates with the daemon's snapshot list

🤖 Generated with [Claude Code](https://claude.com/claude-code)