### PR TITLE
feat(lile): structured error envelope + request IDs on /v1/*

### DIFF
--- a/lile/console/demo.html
+++ b/lile/console/demo.html
@@ -517,7 +517,12 @@ async function runGeneration(userTurnIdx) {
         if (data === "[DONE]") { buf = ""; break; }
         let ev; try { ev = JSON.parse(data); } catch { continue; }
         const lile = ev.lile || {};
-        if (lile.error) { errMsg = lile.error; continue; }
+        if (lile.error) {
+          // Post-#19 lile.error is an object {code,message,retryable,request_id}.
+          // Fall back to the raw value for older servers that still emit a string.
+          errMsg = lile.error.message || lile.error;
+          continue;
+        }
         if (lile.response_id) rid = lile.response_id;
         if (lile.commit_cursor != null) commit = lile.commit_cursor;
         const d = ev.choices?.[0]?.delta || {};

--- a/lile/controller.py
+++ b/lile/controller.py
@@ -388,12 +388,16 @@ class Controller:
 
     async def submit_feedback(self, payload: dict[str, Any]) -> dict[str, Any]:
         """Route feedback to the appropriate training objective (see §5b.3/§5c.16)."""
+        from .errors import InvalidInputError, UnknownResponseIdError
+
         rid = payload.get("response_id")
         kind = payload.get("kind")
         prior = self._response_index.get(rid) if rid else None
         if prior is None and "prompt" not in payload:
-            return {"error": f"unknown response_id {rid!r}; include prompt in payload "
-                             "to bypass index lookup"}
+            raise UnknownResponseIdError(
+                f"unknown response_id {rid!r}; include prompt in payload "
+                "to bypass index lookup"
+            )
 
         prompt_fallback = (prior.get("messages", [{}])[-1].get("content")
                            if prior else None)
@@ -417,7 +421,9 @@ class Controller:
             response_fallback=response_fallback,
         )
         if spec is None:
-            return {"error": f"unsupported or under-specified feedback kind {kind!r}"}
+            raise InvalidInputError(
+                f"unsupported or under-specified feedback kind {kind!r}"
+            )
         return await self.submit_train(spec)
 
     async def request_merge(self) -> dict[str, Any]:

--- a/lile/errors.py
+++ b/lile/errors.py
@@ -1,0 +1,114 @@
+"""Structured error envelope + closed code taxonomy for `/v1/*`.
+
+Every `/v1/*` response that carries an error uses this envelope shape:
+
+    {"error": {"code": "<stable-string>",
+               "message": "<human-readable>",
+               "retryable": <bool>,
+               "request_id": "req_<hex16>"}}
+
+`code` is drawn from `ERROR_CODES` — adding is fine, removing/renaming is a
+breaking change for clients. `retryable` is a hint to clients (hard-coded
+backoff on `True`); the server itself does not retry.
+
+See issue #12 for the full rationale.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+# Closed-enum taxonomy. Read by clients, referenced by tests. Add new codes
+# here and in the table below; never remove.
+ERROR_CODES: frozenset[str] = frozenset({
+    "invalid_input",
+    "unknown_objective",
+    "unknown_response_id",
+    "not_found",
+    "queue_full",
+    "shutting_down",
+    "shutdown_dropped",
+    "timeout",
+    "internal",
+})
+
+
+class LileError(Exception):
+    """Base class for all structured errors surfaced on the wire.
+
+    Subclasses override ``code``, ``status_code``, and ``retryable``. The
+    message comes from ``Exception.__str__`` (i.e. the constructor arg).
+    """
+
+    code: str = "internal"
+    status_code: int = 500
+    retryable: bool = False
+
+
+class InvalidInputError(LileError):
+    code = "invalid_input"
+    status_code = 400
+    retryable = False
+
+
+class UnknownObjectiveError(LileError):
+    code = "unknown_objective"
+    status_code = 400
+    retryable = False
+
+
+class UnknownResponseIdError(LileError):
+    code = "unknown_response_id"
+    status_code = 404
+    retryable = False
+
+
+class NotFoundError(LileError):
+    code = "not_found"
+    status_code = 404
+    retryable = False
+
+
+class QueueFullError(LileError):
+    code = "queue_full"
+    status_code = 503
+    retryable = True
+
+
+class ShuttingDownError(LileError):
+    code = "shutting_down"
+    status_code = 503
+    retryable = True
+
+
+class ShutdownDroppedError(LileError):
+    code = "shutdown_dropped"
+    status_code = 503
+    retryable = True
+
+
+class TimeoutError(LileError):  # noqa: A001 — intentional shadow within this module
+    code = "timeout"
+    status_code = 504
+    retryable = True
+
+
+def envelope_payload(
+    *,
+    code: str,
+    message: str,
+    request_id: str,
+    retryable: bool = False,
+) -> dict[str, Any]:
+    """Return the JSON body that goes on the wire.
+
+    The top-level key is always ``"error"`` so a valid 2xx response (without
+    an "error" key) is unambiguous.
+    """
+    return {
+        "error": {
+            "code": code,
+            "message": message,
+            "retryable": bool(retryable),
+            "request_id": request_id,
+        },
+    }

--- a/lile/middleware.py
+++ b/lile/middleware.py
@@ -1,0 +1,78 @@
+"""Request-ID middleware, contextvar, and logging filter.
+
+Every `/v1/*` request gets an ``X-Request-ID`` header on the response — either
+echoed from the incoming header or freshly minted as ``req_<hex16>``. The id
+is stashed on a ``contextvars.ContextVar`` so downstream code (exception
+handlers, trajectory logging, log records) can pick it up without threading
+it through every call.
+
+See issue #12 for the design note.
+"""
+from __future__ import annotations
+
+import contextvars
+import logging
+import secrets
+from typing import Optional
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+from starlette.types import ASGIApp
+
+
+_REQUEST_ID_CTX: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "lile_request_id", default=None,
+)
+
+REQUEST_ID_HEADER = "X-Request-ID"
+
+
+def new_request_id() -> str:
+    """Return a fresh `req_<hex16>` identifier."""
+    return "req_" + secrets.token_hex(8)
+
+
+def current_request_id() -> Optional[str]:
+    """Return the request id bound to the current async/thread context, if any."""
+    return _REQUEST_ID_CTX.get()
+
+
+def set_request_id(request_id: str) -> contextvars.Token:
+    """Manually bind a request id. Returns a token for ``_REQUEST_ID_CTX.reset``.
+
+    Prefer ``RequestIDMiddleware`` in FastAPI. This helper exists for tests
+    and for background tasks that want to inherit an id.
+    """
+    return _REQUEST_ID_CTX.set(request_id)
+
+
+class RequestIDMiddleware(BaseHTTPMiddleware):
+    """Read/generate ``X-Request-ID``, bind to contextvar, echo on response."""
+
+    def __init__(self, app: ASGIApp, header_name: str = REQUEST_ID_HEADER) -> None:
+        super().__init__(app)
+        self.header_name = header_name
+
+    async def dispatch(self, request: Request, call_next):
+        incoming = request.headers.get(self.header_name)
+        rid = incoming if incoming else new_request_id()
+        token = _REQUEST_ID_CTX.set(rid)
+        try:
+            response: Response = await call_next(request)
+        finally:
+            _REQUEST_ID_CTX.reset(token)
+        response.headers[self.header_name] = rid
+        return response
+
+
+class RequestIdLogFilter(logging.Filter):
+    """Inject ``record.request_id`` from the contextvar (or ``"-"`` if unset).
+
+    Pair with a formatter like ``%(request_id)s`` to see the id in log lines.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        rid = _REQUEST_ID_CTX.get()
+        record.request_id = rid if rid is not None else "-"
+        return True

--- a/lile/server.py
+++ b/lile/server.py
@@ -18,6 +18,9 @@ from pydantic import BaseModel, Field
 
 from .config import ServeConfig
 from .controller import Controller
+from .errors import NotFoundError
+from .middleware import RequestIDMiddleware, current_request_id
+from .server_errors import register_error_handlers
 
 log = logging.getLogger(__name__)
 
@@ -98,6 +101,8 @@ def create_app(cfg: ServeConfig | None = None) -> FastAPI:
     app = FastAPI(title="lile", version="0.1.0-dev")
     app.state.cfg = cfg
     app.state.controller = Controller(cfg)
+    app.add_middleware(RequestIDMiddleware)
+    register_error_handlers(app)
 
     @app.on_event("startup")
     async def _startup() -> None:
@@ -139,12 +144,20 @@ def create_app(cfg: ServeConfig | None = None) -> FastAPI:
                         parse_reasoning=req.parse_reasoning,
                     ):
                         if "error" in ev:
+                            rid = current_request_id() or ""
                             payload = {
                                 "object": "chat.completion.chunk",
                                 "model": cfg.model,
                                 "choices": [{"index": 0, "delta": {}, "finish_reason": "error"}],
-                                "lile": {"error": ev["error"],
-                                         "response_id": ev["response_id"]},
+                                "lile": {
+                                    "error": {
+                                        "code": "internal",
+                                        "message": str(ev["error"]),
+                                        "retryable": False,
+                                        "request_id": rid,
+                                    },
+                                    "response_id": ev["response_id"],
+                                },
                             }
                             yield f"data: {json.dumps(payload)}\n\n"
                             yield "data: [DONE]\n\n"
@@ -180,10 +193,18 @@ def create_app(cfg: ServeConfig | None = None) -> FastAPI:
                         }
                         yield f"data: {json.dumps(payload)}\n\n"
                 except Exception as exc:
+                    rid = current_request_id() or ""
                     err_payload = {
                         "object": "chat.completion.chunk",
                         "choices": [{"index": 0, "delta": {}, "finish_reason": "error"}],
-                        "lile": {"error": f"{type(exc).__name__}: {exc}"},
+                        "lile": {
+                            "error": {
+                                "code": "internal",
+                                "message": f"{type(exc).__name__}: {exc}",
+                                "retryable": False,
+                                "request_id": rid,
+                            },
+                        },
                     }
                     yield f"data: {json.dumps(err_payload)}\n\n"
                     yield "data: [DONE]\n\n"
@@ -268,7 +289,7 @@ def create_app(cfg: ServeConfig | None = None) -> FastAPI:
         except asyncio.TimeoutError:
             return {"committed": False, "reason": "timeout"}
         except KeyError:
-            raise HTTPException(404, detail=f"unknown token {token}")
+            raise NotFoundError(f"unknown commit token {token}")
 
     return app
 

--- a/lile/server_errors.py
+++ b/lile/server_errors.py
@@ -101,11 +101,15 @@ def register_error_handlers(app: FastAPI) -> None:
             status,
             "internal" if status >= 500 else "invalid_input",
         )
+        # Only transient upstream statuses are retryable. 500 stays non-retryable
+        # to match ``_fallback_handler`` (which also catches uncaught exceptions
+        # and hands them back as 500 internal) — clients should not blind-retry
+        # an internal server error.
         return _respond(
             status_code=status,
             code=code,
             message=str(exc.detail) if exc.detail else code,
-            retryable=status >= 500 and status != 501,
+            retryable=status in (502, 503, 504),
         )
 
     @app.exception_handler(Exception)

--- a/lile/server_errors.py
+++ b/lile/server_errors.py
@@ -1,0 +1,120 @@
+"""FastAPI exception handlers that emit the ``lile.errors`` envelope.
+
+Call ``register_error_handlers(app)`` once during ``create_app`` to wire:
+
+- ``LileError`` subclasses → envelope with their own ``status_code`` / ``code``
+- ``HTTPException`` → envelope, preserving the HTTP status
+- ``RequestValidationError`` → envelope with ``code="invalid_input"``, HTTP 400
+- Everything else → envelope with ``code="internal"``, HTTP 500
+
+All envelopes include a ``request_id`` read from the ``lile.middleware``
+contextvar. An ``X-Request-ID`` response header is set to match, so clients
+that only inspect headers still see the id.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import FastAPI, HTTPException
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+from starlette.requests import Request
+
+from .errors import LileError, envelope_payload
+from .middleware import REQUEST_ID_HEADER, current_request_id, new_request_id
+
+log = logging.getLogger(__name__)
+
+
+# HTTPException status → taxonomy code. Anything not here falls back to
+# "internal" for 5xx and "not_found" / "invalid_input" heuristic for 4xx.
+_HTTP_STATUS_TO_CODE: dict[int, str] = {
+    400: "invalid_input",
+    404: "not_found",
+    503: "shutting_down",
+    504: "timeout",
+}
+
+
+def _resolve_request_id() -> str:
+    rid = current_request_id()
+    return rid if rid is not None else new_request_id()
+
+
+def _respond(
+    *,
+    status_code: int,
+    code: str,
+    message: str,
+    retryable: bool,
+) -> JSONResponse:
+    rid = _resolve_request_id()
+    body = envelope_payload(
+        code=code, message=message, retryable=retryable, request_id=rid,
+    )
+    return JSONResponse(
+        status_code=status_code,
+        content=body,
+        headers={REQUEST_ID_HEADER: rid},
+    )
+
+
+def _format_validation_message(errors: list[dict[str, Any]]) -> str:
+    # FastAPI's default is a list of dicts with loc/msg/type; we flatten to
+    # a single short message for humans. Full detail stays in logs.
+    bits: list[str] = []
+    for e in errors[:3]:  # cap the wire payload
+        loc = ".".join(str(x) for x in e.get("loc", []) if x != "body")
+        msg = e.get("msg", "invalid value")
+        bits.append(f"{loc or 'body'}: {msg}" if loc else msg)
+    if len(errors) > 3:
+        bits.append(f"(+{len(errors) - 3} more)")
+    return "; ".join(bits) or "invalid input"
+
+
+def register_error_handlers(app: FastAPI) -> None:
+    @app.exception_handler(LileError)
+    async def _lile_error_handler(_req: Request, exc: LileError) -> JSONResponse:
+        return _respond(
+            status_code=exc.status_code,
+            code=exc.code,
+            message=str(exc) or exc.code,
+            retryable=exc.retryable,
+        )
+
+    @app.exception_handler(RequestValidationError)
+    async def _validation_handler(
+        _req: Request, exc: RequestValidationError,
+    ) -> JSONResponse:
+        return _respond(
+            status_code=400,
+            code="invalid_input",
+            message=_format_validation_message(exc.errors()),
+            retryable=False,
+        )
+
+    @app.exception_handler(HTTPException)
+    async def _http_handler(_req: Request, exc: HTTPException) -> JSONResponse:
+        status = exc.status_code
+        code = _HTTP_STATUS_TO_CODE.get(
+            status,
+            "internal" if status >= 500 else "invalid_input",
+        )
+        return _respond(
+            status_code=status,
+            code=code,
+            message=str(exc.detail) if exc.detail else code,
+            retryable=status >= 500 and status != 501,
+        )
+
+    @app.exception_handler(Exception)
+    async def _fallback_handler(_req: Request, exc: Exception) -> JSONResponse:
+        # Never leak exception internals to clients, but do log.
+        log.exception("unhandled exception in /v1/* route: %s", exc)
+        return _respond(
+            status_code=500,
+            code="internal",
+            message="internal server error",
+            retryable=False,
+        )

--- a/lile/tests/test_error_middleware.py
+++ b/lile/tests/test_error_middleware.py
@@ -48,6 +48,14 @@ def _build_app() -> FastAPI:
     async def boom_http_404() -> dict:
         raise HTTPException(status_code=404, detail="not here")
 
+    @app.get("/boom-http-500")
+    async def boom_http_500() -> dict:
+        raise HTTPException(status_code=500, detail="internal")
+
+    @app.get("/boom-http-502")
+    async def boom_http_502() -> dict:
+        raise HTTPException(status_code=502, detail="bad gateway")
+
     @app.get("/boom-invalid")
     async def boom_invalid() -> dict:
         raise InvalidInputError("samples must be non-empty")
@@ -167,6 +175,24 @@ def test_shutting_down_is_retryable_503():
         r = client.get("/boom-shutting-down")
     assert r.status_code == 503
     _assert_envelope(r.json(), code="shutting_down", retryable=True)
+
+
+def test_http_500_is_not_retryable():
+    """Align with ``_fallback_handler`` — plain 500 is internal, not transient."""
+    app = _build_app()
+    with TestClient(app) as client:
+        r = client.get("/boom-http-500")
+    assert r.status_code == 500
+    _assert_envelope(r.json(), code="internal", retryable=False)
+
+
+def test_http_502_is_retryable():
+    """Upstream gateway errors are the only 5xx statuses we flag retryable."""
+    app = _build_app()
+    with TestClient(app) as client:
+        r = client.get("/boom-http-502")
+    assert r.status_code == 502
+    _assert_envelope(r.json(), code="internal", retryable=True)
 
 
 def test_pydantic_validation_error_becomes_envelope_400():

--- a/lile/tests/test_error_middleware.py
+++ b/lile/tests/test_error_middleware.py
@@ -1,0 +1,235 @@
+"""FastAPI-level tests for request-ID middleware + exception handlers.
+
+These pin the wire contract for `/v1/*` error responses without loading a
+model. We mount `register_error_handlers(app)` + `RequestIDMiddleware` on a
+minimal app with stub routes that raise the relevant exceptions, then
+probe it with TestClient.
+
+Run with: pytest lile/tests/test_error_middleware.py
+"""
+from __future__ import annotations
+
+import logging
+import re
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.cpu_only
+
+
+REQ_ID_RE = re.compile(r"^req_[0-9a-f]{16}$")
+
+
+def _build_app() -> FastAPI:
+    from lile.errors import (
+        InvalidInputError,
+        QueueFullError,
+        ShuttingDownError,
+        UnknownResponseIdError,
+    )
+    from lile.middleware import RequestIDMiddleware, current_request_id
+    from lile.server_errors import register_error_handlers
+
+    app = FastAPI()
+    app.add_middleware(RequestIDMiddleware)
+    register_error_handlers(app)
+
+    @app.get("/ok")
+    async def ok() -> dict:
+        return {"ok": True, "rid": current_request_id()}
+
+    @app.get("/boom-value")
+    async def boom_value() -> dict:
+        raise ValueError("boom")
+
+    @app.get("/boom-http-404")
+    async def boom_http_404() -> dict:
+        raise HTTPException(status_code=404, detail="not here")
+
+    @app.get("/boom-invalid")
+    async def boom_invalid() -> dict:
+        raise InvalidInputError("samples must be non-empty")
+
+    @app.get("/boom-unknown-rid")
+    async def boom_unknown_rid() -> dict:
+        raise UnknownResponseIdError("r_missing")
+
+    @app.get("/boom-queue-full")
+    async def boom_queue_full() -> dict:
+        raise QueueFullError("queue depth exceeded")
+
+    @app.get("/boom-shutting-down")
+    async def boom_shutting_down() -> dict:
+        raise ShuttingDownError("daemon is shutting down")
+
+    from pydantic import BaseModel
+
+    class Payload(BaseModel):
+        name: str
+
+    @app.post("/needs-body")
+    async def needs_body(p: Payload) -> dict:
+        return {"name": p.name}
+
+    return app
+
+
+# ---------------------------------------------------------------- request ID middleware
+
+def test_middleware_generates_request_id_when_header_missing():
+    app = _build_app()
+    with TestClient(app) as client:
+        r = client.get("/ok")
+    assert r.status_code == 200
+    rid = r.headers.get("x-request-id")
+    assert rid is not None
+    assert REQ_ID_RE.match(rid), rid
+    assert r.json()["rid"] == rid
+
+
+def test_middleware_passes_through_incoming_x_request_id():
+    app = _build_app()
+    with TestClient(app) as client:
+        r = client.get("/ok", headers={"X-Request-ID": "req_clientsupplied1"})
+    assert r.headers["x-request-id"] == "req_clientsupplied1"
+    assert r.json()["rid"] == "req_clientsupplied1"
+
+
+def test_middleware_different_requests_get_different_ids():
+    app = _build_app()
+    with TestClient(app) as client:
+        a = client.get("/ok").headers["x-request-id"]
+        b = client.get("/ok").headers["x-request-id"]
+    assert a != b
+
+
+# ---------------------------------------------------------------- exception handlers
+
+def _assert_envelope(body: dict, *, code: str, retryable: bool) -> dict:
+    assert set(body.keys()) == {"error"}
+    err = body["error"]
+    assert err["code"] == code
+    assert err["retryable"] is retryable
+    assert isinstance(err["message"], str) and err["message"]
+    assert REQ_ID_RE.match(err["request_id"]), err["request_id"]
+    return err
+
+
+def test_generic_exception_becomes_500_envelope():
+    app = _build_app()
+    with TestClient(app, raise_server_exceptions=False) as client:
+        r = client.get("/boom-value")
+    assert r.status_code == 500
+    err = _assert_envelope(r.json(), code="internal", retryable=False)
+    assert r.headers["x-request-id"] == err["request_id"]
+
+
+def test_http_exception_becomes_envelope_with_matching_status():
+    app = _build_app()
+    with TestClient(app) as client:
+        r = client.get("/boom-http-404")
+    assert r.status_code == 404
+    _assert_envelope(r.json(), code="not_found", retryable=False)
+
+
+def test_invalid_input_error_becomes_400_envelope():
+    app = _build_app()
+    with TestClient(app) as client:
+        r = client.get("/boom-invalid")
+    assert r.status_code == 400
+    err = _assert_envelope(r.json(), code="invalid_input", retryable=False)
+    assert "samples must be non-empty" in err["message"]
+
+
+def test_unknown_response_id_becomes_404_envelope():
+    """PIN the /v1/feedback status-code bug fix (was 200 + {"error":...})."""
+    app = _build_app()
+    with TestClient(app) as client:
+        r = client.get("/boom-unknown-rid")
+    assert r.status_code == 404
+    err = _assert_envelope(r.json(), code="unknown_response_id", retryable=False)
+    assert "r_missing" in err["message"]
+
+
+def test_queue_full_is_retryable_503():
+    app = _build_app()
+    with TestClient(app) as client:
+        r = client.get("/boom-queue-full")
+    assert r.status_code == 503
+    _assert_envelope(r.json(), code="queue_full", retryable=True)
+
+
+def test_shutting_down_is_retryable_503():
+    app = _build_app()
+    with TestClient(app) as client:
+        r = client.get("/boom-shutting-down")
+    assert r.status_code == 503
+    _assert_envelope(r.json(), code="shutting_down", retryable=True)
+
+
+def test_pydantic_validation_error_becomes_envelope_400():
+    app = _build_app()
+    with TestClient(app) as client:
+        r = client.post("/needs-body", json={"wrong": "shape"})
+    assert r.status_code == 400
+    err = _assert_envelope(r.json(), code="invalid_input", retryable=False)
+    # FastAPI's default error has `loc`/`msg`; the envelope just needs to be human-readable.
+    assert err["message"]  # non-empty
+
+
+# ---------------------------------------------------------------- trajectory contextvar
+
+def test_trajectory_stamps_request_id_when_set(tmp_path):
+    from lile.middleware import _REQUEST_ID_CTX, current_request_id, set_request_id
+    from lile.trajectory import TrajectoryLog
+
+    log = TrajectoryLog(tmp_path / "t.jsonl")
+
+    token = set_request_id("req_trajstamp000001")
+    try:
+        log.log_event("test_event", {"k": 1})
+        assert current_request_id() == "req_trajstamp000001"
+    finally:
+        _REQUEST_ID_CTX.reset(token)
+
+    events = log.tail(1)
+    assert events[0]["kind"] == "test_event"
+    assert events[0]["request_id"] == "req_trajstamp000001"
+
+
+def test_trajectory_omits_request_id_when_unset(tmp_path):
+    from lile.trajectory import TrajectoryLog
+
+    log = TrajectoryLog(tmp_path / "t.jsonl")
+    log.log_event("test_event", {"k": 1})
+    ev = log.tail(1)[0]
+    assert "request_id" not in ev
+
+
+# ---------------------------------------------------------------- logging filter
+
+def test_log_records_carry_request_id(caplog):
+    from lile.middleware import (
+        RequestIdLogFilter,
+        _REQUEST_ID_CTX,
+        set_request_id,
+    )
+
+    logger = logging.getLogger("lile.test_rid")
+    logger.setLevel(logging.INFO)
+    filt = RequestIdLogFilter()
+    logger.addFilter(filt)
+
+    token = set_request_id("req_logtest0000001")
+    try:
+        with caplog.at_level(logging.INFO, logger="lile.test_rid"):
+            logger.info("hello from request")
+    finally:
+        _REQUEST_ID_CTX.reset(token)
+
+    assert caplog.records
+    rec = caplog.records[-1]
+    assert getattr(rec, "request_id", None) == "req_logtest0000001"
+    logger.removeFilter(filt)

--- a/lile/tests/test_errors.py
+++ b/lile/tests/test_errors.py
@@ -1,0 +1,101 @@
+"""Unit tests for `lile.errors` — envelope shape and code taxonomy.
+
+The envelope is the contract every `/v1/*` response uses when something goes
+wrong. Every follow-up (metrics, admission control, auth) reads `error.code`
+and `error.retryable`, so the shape is load-bearing.
+
+Run with: pytest lile/tests/test_errors.py
+"""
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.cpu_only
+
+
+def test_envelope_shape_is_nested_under_error_key():
+    from lile.errors import envelope_payload
+
+    payload = envelope_payload(
+        code="invalid_input",
+        message="samples[0].prompt is required",
+        retryable=False,
+        request_id="req_deadbeefdeadbeef",
+    )
+    assert set(payload.keys()) == {"error"}
+    err = payload["error"]
+    assert err["code"] == "invalid_input"
+    assert err["message"] == "samples[0].prompt is required"
+    assert err["retryable"] is False
+    assert err["request_id"] == "req_deadbeefdeadbeef"
+
+
+def test_envelope_default_retryable_is_false():
+    from lile.errors import envelope_payload
+
+    payload = envelope_payload(code="internal", message="x", request_id="req_x")
+    assert payload["error"]["retryable"] is False
+
+
+def test_code_taxonomy_is_closed_set():
+    from lile.errors import ERROR_CODES
+
+    expected = {
+        "invalid_input",
+        "unknown_objective",
+        "unknown_response_id",
+        "not_found",
+        "queue_full",
+        "shutting_down",
+        "shutdown_dropped",
+        "timeout",
+        "internal",
+    }
+    # Taxonomy must be at least this big. Adding new codes is fine; removing
+    # is a breaking change for clients and requires an ADR.
+    assert expected <= set(ERROR_CODES)
+
+
+def test_lile_error_subclasses_carry_code_and_status():
+    from lile.errors import (
+        InvalidInputError,
+        NotFoundError,
+        QueueFullError,
+        ShuttingDownError,
+        TimeoutError as LileTimeoutError,
+        UnknownResponseIdError,
+    )
+
+    assert InvalidInputError("x").code == "invalid_input"
+    assert InvalidInputError("x").status_code == 400
+
+    assert UnknownResponseIdError("r_deadbeef").code == "unknown_response_id"
+    assert UnknownResponseIdError("r_deadbeef").status_code == 404
+
+    assert NotFoundError("x").code == "not_found"
+    assert NotFoundError("x").status_code == 404
+
+    assert QueueFullError("x").code == "queue_full"
+    assert QueueFullError("x").status_code == 503
+    assert QueueFullError("x").retryable is True
+
+    assert ShuttingDownError("x").code == "shutting_down"
+    assert ShuttingDownError("x").status_code == 503
+    assert ShuttingDownError("x").retryable is True
+
+    assert LileTimeoutError("x").code == "timeout"
+    assert LileTimeoutError("x").status_code == 504
+
+
+def test_lile_error_default_message_goes_to_envelope():
+    from lile.errors import InvalidInputError, envelope_payload
+
+    exc = InvalidInputError("samples must be non-empty")
+    payload = envelope_payload(
+        code=exc.code,
+        message=str(exc),
+        retryable=exc.retryable,
+        request_id="req_test",
+    )
+    assert payload["error"]["message"] == "samples must be non-empty"
+    assert payload["error"]["code"] == "invalid_input"

--- a/lile/tests/test_feedback_errors.py
+++ b/lile/tests/test_feedback_errors.py
@@ -1,0 +1,58 @@
+"""Controller-level tests: /v1/feedback raises structured errors.
+
+Pins the pre-fix bug where unknown response_id returned HTTP 200 with a
+``{"error": "..."}`` body. After #12 the controller raises
+``UnknownResponseIdError`` / ``InvalidInputError`` and the server envelope
+handler converts them to 404 / 400 responses.
+
+These tests hit the pure-Python Controller path (no model loaded).
+
+Run with: pytest lile/tests/test_feedback_errors.py
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from lile.config import ServeConfig
+from lile.controller import Controller
+from lile.errors import InvalidInputError, UnknownResponseIdError
+
+pytestmark = pytest.mark.cpu_only
+
+
+def _make_controller(tmp_path: Path) -> Controller:
+    cfg = ServeConfig(data_dir=tmp_path)
+    return Controller(cfg)
+
+
+def test_unknown_response_id_raises_structured_error(tmp_path):
+    c = _make_controller(tmp_path)
+    with pytest.raises(UnknownResponseIdError) as ei:
+        asyncio.run(c.submit_feedback({
+            "response_id": "r_nonexistent",
+            "kind": "binary",
+        }))
+    assert "r_nonexistent" in str(ei.value)
+
+
+def test_missing_response_id_and_prompt_raises(tmp_path):
+    c = _make_controller(tmp_path)
+    # No response_id, no prompt — can't possibly identify a prior turn.
+    with pytest.raises(UnknownResponseIdError):
+        asyncio.run(c.submit_feedback({"kind": "binary"}))
+
+
+def test_underspecified_kind_raises_invalid_input(tmp_path):
+    c = _make_controller(tmp_path)
+    # Provide prompt so we bypass the response_id lookup, but pass an
+    # unsupported feedback kind so feedback_to_batch returns None.
+    with pytest.raises(InvalidInputError) as ei:
+        asyncio.run(c.submit_feedback({
+            "prompt": "Q",
+            "response": "A",
+            "kind": "totally_made_up_kind",
+        }))
+    assert "totally_made_up_kind" in str(ei.value)

--- a/lile/trajectory.py
+++ b/lile/trajectory.py
@@ -50,8 +50,22 @@ class TrajectoryLog:
         return offset
 
     def log_event(self, kind: str, data: dict[str, Any]) -> int:
-        """Append a `{kind, ts, ...data}` line. Returns byte offset of the new line."""
-        payload = {"kind": kind, "ts": time.time(), **data}
+        """Append a `{kind, ts, ...data}` line. Returns byte offset of the new line.
+
+        If a request-scoped id is bound via ``lile.middleware.current_request_id``,
+        it is stamped into the record under ``request_id``. Internal tasks
+        (replay, queue-driven retrains) leave it absent.
+        """
+        payload: dict[str, Any] = {"kind": kind, "ts": time.time(), **data}
+        # Lazy import to keep trajectory importable without starlette (tests
+        # that exercise only the writer don't need the web stack).
+        try:
+            from .middleware import current_request_id  # noqa: PLC0415
+            rid = current_request_id()
+        except Exception:
+            rid = None
+        if rid is not None and "request_id" not in payload:
+            payload["request_id"] = rid
         return self.append_raw(payload)
 
     def log_inference(self, response_id: str, prompt: str, response: str,


### PR DESCRIPTION
## Summary

Closes #12. Foundational prod-integrity change: every `/v1/*` response that carries an error now uses a single envelope, and every request carries a stable `X-Request-ID` that is echoed on the response and stamped into trajectory records.

Envelope shape:
```json
{"error": {"code": "<stable>", "message": "<human>", "retryable": <bool>, "request_id": "req_<hex16>"}}
```

## What changed

- **`lile/errors.py`** — closed code taxonomy (`ERROR_CODES`) + typed exceptions (`InvalidInputError`, `UnknownResponseIdError`, `QueueFullError`, `ShuttingDownError`, `TimeoutError`, `NotFoundError`, …) carrying `status_code` and `retryable`.
- **`lile/middleware.py`** — `RequestIDMiddleware` reads/generates `X-Request-ID`, binds to a `contextvars.ContextVar`, echoes on response. `RequestIdLogFilter` injects the id into log records.
- **`lile/server_errors.py`** — FastAPI handlers for `LileError`, `HTTPException`, `RequestValidationError`, and catch-all `Exception`. All emit the envelope with a matching `X-Request-ID` header.
- **`lile/server.py`** — wires middleware + handlers into `create_app`; updates SSE error payload shape; `/v1/wait` raises `NotFoundError` instead of a bare `HTTPException(404)`.
- **`lile/controller.py`** — `submit_feedback` raises `UnknownResponseIdError` / `InvalidInputError` instead of returning HTTP 200 with a `{"error": "..."}` body (was lying to clients — #12 callout).
- **`lile/trajectory.py`** — `log_event` stamps the current request id into every record when one is bound. Additive — byte-offset stability preserved for `IdleReplayScheduler` dedup.

## Tests

23 new cpu_only cases:

- `test_errors.py` — envelope shape, closed taxonomy, subclass status/code/retryable.
- `test_error_middleware.py` — middleware generates/passes through id; handlers produce envelope for `ValueError`/`HTTPException`/validation/`LileError` subclasses; trajectory stamps `request_id` from contextvar; log filter injects it into records. Includes `test_http_500_is_not_retryable` / `test_http_502_is_retryable` pinning the aligned retryable semantics.
- `test_feedback_errors.py` — controller raises structured errors on unknown `response_id` / unsupported feedback kind.

Full `cpu_only` suite: **57 passed, 0 failures**.

## Test plan

- [x] `uv run --active pytest lile/tests/ -m cpu_only` → all green
- [ ] Smoke server test (GPU): manual run by reviewer — `uv run python -m lile.tests.smoke_server`
- [ ] Studio frontend: fetch hooks currently assume 2xx JSON — a follow-up will read `response.json().error.{code,message,retryable}` and surface to UI. Flagged on the PO track.

## Breaking changes for clients

- `POST /v1/feedback` with unknown `response_id` now returns **HTTP 404** with envelope (was 200 with `{"error": "..."}`). This was a bug fix.
- `POST /v1/wait` with unknown token now returns envelope (was `{"detail": "..."}`).
- SSE error chunk now carries `lile.error = {code, message, retryable, request_id}` (was `lile.error = "<string>"`).
- **Pydantic validation errors now return HTTP 400** (envelope with `code="invalid_input"`). FastAPI's default is 422; we chose 400 so `invalid_input` has a single HTTP status across manual and pydantic validation paths. If you had clients keyed on 422, switch to `error.code == "invalid_input"`.

Clients parsing either response shape should switch to `response.error.message` / `response.error.code`.

## Follow-ups addressed in f8a7b139

Three non-blocking items from the review, landed as a follow-up commit on this PR:

- `lile/console/demo.html` — read `lile.error.message` in SSE handling (was rendering `[object Object]`).
- `server_errors.py::_http_handler` — 5xx retryable semantic aligned with `_fallback_handler`: only **502/503/504** are retryable. Plain 500 is internal → not retryable (matches what the fallback handler already emits for uncaught exceptions).
- Two new middleware tests pinning the aligned retryable behavior.

## Follow-ups (separate issues)

- Studio frontend: read the envelope in `lile-client.ts` + display `error.code`.
- #13 Prometheus metrics — now trivially consumes the `request_id` for exemplars.
- #14 admission control — raises `QueueFullError`; envelope already shaped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)