### PR TITLE
feat(lile): Prometheus /metrics endpoint

### DIFF
--- a/lile/controller.py
+++ b/lile/controller.py
@@ -108,21 +108,33 @@ class Controller:
         if kind == "train":
             result = self.train_engine.step(payload)
             components = result.get("components")
+            wall = time.time() - t0
+            objective = payload.get("objective", "") or "unknown"
             # Canonical log entry for every committed step.
             self.trajectory.log_train(
                 batch_id=task.batch_id,
-                objective=payload.get("objective", ""),
+                objective=objective,
                 loss=result.get("loss") or 0.0,
                 batch_size=len(payload.get("samples", [])),
                 commit_token=task.token,
                 components=components,
             )
+            # Prometheus counters + latency/loss histograms.
+            try:
+                from . import metrics as metrics_mod  # noqa: PLC0415
+                metrics_mod.record_train_step(
+                    objective=objective,
+                    latency_s=wall,
+                    loss=result.get("loss"),
+                )
+            except Exception as exc:  # pragma: no cover — metrics must not break training
+                log.warning("metrics record_train_step failed: %s", exc)
             # Fan out scalar metrics to the external sink (no-op for NullLogger).
             scalars = flatten_scalars(components or {})
             if scalars:
                 self.metrics_logger.log_metrics(scalars, step=task.token)
             return {"loss": result.get("loss"), "components": components,
-                    "wall": time.time() - t0}
+                    "wall": wall}
         elif kind == "merge":
             self.state.merge_active_into_residual()
             return {"merges_applied": self.state.merges_applied,
@@ -391,10 +403,12 @@ class Controller:
 
     async def submit_feedback(self, payload: dict[str, Any]) -> dict[str, Any]:
         """Route feedback to the appropriate training objective (see §5b.3/§5c.16)."""
+        from . import metrics as metrics_mod
         from .errors import InvalidInputError, UnknownResponseIdError
 
         rid = payload.get("response_id")
         kind = payload.get("kind")
+        metrics_mod.record_feedback_event(kind=kind or "unknown")
         prior = self._response_index.get(rid) if rid else None
         if prior is None and "prompt" not in payload:
             raise UnknownResponseIdError(

--- a/lile/metrics.py
+++ b/lile/metrics.py
@@ -1,0 +1,323 @@
+"""Prometheus metrics surface for the lile daemon.
+
+Exposes `GET /metrics` in the standard Prometheus text exposition format.
+Metrics come from two sources:
+
+- **Counters / histograms** — updated in-line by callers (middleware, the
+  Controller's task handler, the chat route). Cheap, hot-path safe.
+- **Gauges** — sampled lazily at scrape time via a custom Collector bound to
+  the live Controller. This keeps a single source of truth — the gauge value
+  is whatever the Controller reports right now, not a shadow counter that
+  can drift.
+
+See issue #13 for the full spec.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+from prometheus_client import (
+    CollectorRegistry,
+    Counter,
+    Histogram,
+    generate_latest,
+)
+from prometheus_client.core import GaugeMetricFamily
+from prometheus_client.registry import Collector
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+from starlette.types import ASGIApp
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------- registry
+
+# Private registry — do not share with the default `prometheus_client.REGISTRY`
+# global so test runs don't accumulate duplicate collectors across pytest
+# sessions and so other libs can't clobber our metric families.
+REGISTRY = CollectorRegistry(auto_describe=True)
+
+
+# ---------------------------------------------------------------- counters
+
+_REQUESTS = Counter(
+    "lile_requests_total",
+    "HTTP requests handled by /v1/* routes, labelled by route and status.",
+    labelnames=("route", "status"),
+    registry=REGISTRY,
+)
+
+_TRAIN_STEPS = Counter(
+    "lile_train_steps_total",
+    "Training steps committed by the compute-queue worker.",
+    labelnames=("objective",),
+    registry=REGISTRY,
+)
+
+_FEEDBACK_EVENTS = Counter(
+    "lile_feedback_events_total",
+    "Feedback payloads accepted on /v1/feedback.",
+    labelnames=("kind",),
+    registry=REGISTRY,
+)
+
+_QUEUE_DROPPED = Counter(
+    "lile_queue_dropped_total",
+    "Compute-queue tasks dropped before commit (reason label: full, shutdown).",
+    labelnames=("reason",),
+    registry=REGISTRY,
+)
+
+_REPLAY_ENQUEUED = Counter(
+    "lile_replay_enqueued_total",
+    "Batches enqueued by the idle replay scheduler.",
+    registry=REGISTRY,
+)
+
+
+# ---------------------------------------------------------------- histograms
+
+# Bucket choices: default prom buckets are tuned for web-request seconds;
+# step latency and generate latency are both naturally in the tens-of-ms
+# to multi-second range, so we use the same bucket family scaled to ms.
+_LATENCY_MS_BUCKETS = (5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 30000)
+
+_STEP_LATENCY = Histogram(
+    "lile_step_latency_ms",
+    "Wall-clock time spent inside TrainEngine.step.",
+    labelnames=("objective",),
+    buckets=_LATENCY_MS_BUCKETS,
+    registry=REGISTRY,
+)
+
+_GENERATE_LATENCY = Histogram(
+    "lile_generate_latency_ms",
+    "Wall-clock time for a chat completion. stream=true means time-to-first-token.",
+    labelnames=("stream",),
+    buckets=_LATENCY_MS_BUCKETS,
+    registry=REGISTRY,
+)
+
+# Loss histogram — bucket chosen to capture the common LLM NLL range.
+_OBJECTIVE_LOSS = Histogram(
+    "lile_objective_loss",
+    "Per-step loss value, labelled by objective.",
+    labelnames=("objective",),
+    buckets=(0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 16.0),
+    registry=REGISTRY,
+)
+
+
+# ---------------------------------------------------------------- lazy gauges
+
+
+class _ControllerGaugeCollector(Collector):
+    """Reads live state off a bound Controller at scrape time.
+
+    The Controller reference is optional — when unbound every gauge reports
+    zero. This keeps the /metrics surface well-defined during daemon startup
+    and in unit tests that don't instantiate a Controller.
+    """
+
+    def __init__(self) -> None:
+        self._controller: Any = None
+
+    def bind(self, controller: Any) -> None:
+        self._controller = controller
+
+    def collect(self) -> Iterable[GaugeMetricFamily]:
+        c = self._controller
+
+        # Queue depth.
+        queue_depth = 0.0
+        commit_cursor = 0.0
+        merges = 0.0
+        traj_bytes = 0.0
+        snap_count = 0.0
+        snap_bytes = 0.0
+        shutting_down = 0.0
+        if c is not None:
+            try:
+                queue_depth = float(c.queue._q.qsize())
+            except Exception:  # pragma: no cover — scrape must never crash
+                pass
+            try:
+                commit_cursor = float(getattr(c.queue, "committed", 0))
+            except Exception:  # pragma: no cover
+                pass
+            try:
+                if c.state is not None:
+                    merges = float(getattr(c.state, "merges_applied", 0))
+            except Exception:  # pragma: no cover
+                pass
+            try:
+                traj_bytes = float(c.trajectory.size())
+            except Exception:  # pragma: no cover
+                pass
+            try:
+                root: Optional[Path] = getattr(c.snapshots, "root", None)
+                if root is not None and Path(root).exists():
+                    snap_count, snap_bytes = _snapshot_stats(Path(root))
+            except Exception:  # pragma: no cover
+                pass
+            try:
+                shutting_down = 1.0 if getattr(c, "_shutting_down", False) else 0.0
+            except Exception:  # pragma: no cover
+                pass
+
+        yield GaugeMetricFamily(
+            "lile_queue_depth",
+            "Compute-queue depth (tasks awaiting the worker).",
+            value=queue_depth,
+        )
+        yield GaugeMetricFamily(
+            "lile_commit_cursor",
+            "Monotone commit cursor (last committed task token).",
+            value=commit_cursor,
+        )
+        yield GaugeMetricFamily(
+            "lile_merges_applied",
+            "Number of adapter→residual merges since daemon start.",
+            value=merges,
+        )
+        yield GaugeMetricFamily(
+            "lile_trajectory_bytes",
+            "Size in bytes of the trajectory JSONL file.",
+            value=traj_bytes,
+        )
+        yield GaugeMetricFamily(
+            "lile_snapshots_count",
+            "Number of on-disk snapshot directories.",
+            value=snap_count,
+        )
+        yield GaugeMetricFamily(
+            "lile_snapshots_bytes",
+            "Total bytes used by the snapshots directory tree.",
+            value=snap_bytes,
+        )
+        yield GaugeMetricFamily(
+            "lile_shutting_down",
+            "1 when the controller is draining for shutdown, 0 otherwise.",
+            value=shutting_down,
+        )
+
+
+def _snapshot_stats(root: Path) -> tuple[float, float]:
+    """Return (count, total_bytes) walked from the snapshots root."""
+    count = 0
+    total = 0
+    for entry in root.iterdir():
+        if entry.is_dir():
+            count += 1
+            for dirpath, _, filenames in os.walk(entry):
+                for fn in filenames:
+                    try:
+                        total += (Path(dirpath) / fn).stat().st_size
+                    except OSError:  # pragma: no cover
+                        continue
+    return float(count), float(total)
+
+
+_GAUGES = _ControllerGaugeCollector()
+REGISTRY.register(_GAUGES)
+
+
+# ---------------------------------------------------------------- public API
+
+
+def bind_controller(controller: Any) -> None:
+    """Bind a Controller (or compatible stub) for lazy gauge scraping.
+
+    Pass ``None`` to detach (gauges then report zero).
+    """
+    _GAUGES.bind(controller)
+
+
+def render_prometheus() -> bytes:
+    """Return the Prometheus text exposition for the lile registry."""
+    return generate_latest(REGISTRY)
+
+
+# ---------------------------------------------------------------- hot-path hooks
+
+
+def record_request(*, route: str, status: int) -> None:
+    """Bump `lile_requests_total{route,status}`. Call once per HTTP response."""
+    _REQUESTS.labels(route=route, status=str(status)).inc()
+
+
+def record_train_step(*, objective: str, latency_s: float, loss: float | None = None) -> None:
+    """Bump `lile_train_steps_total{objective}` + observe latency/loss histograms."""
+    _TRAIN_STEPS.labels(objective=objective or "unknown").inc()
+    _STEP_LATENCY.labels(objective=objective or "unknown").observe(latency_s * 1000.0)
+    if loss is not None:
+        try:
+            _OBJECTIVE_LOSS.labels(objective=objective or "unknown").observe(float(loss))
+        except (TypeError, ValueError):  # pragma: no cover — defensive
+            pass
+
+
+def record_feedback_event(*, kind: str) -> None:
+    """Bump `lile_feedback_events_total{kind}`."""
+    _FEEDBACK_EVENTS.labels(kind=kind or "unknown").inc()
+
+
+def record_queue_drop(*, reason: str) -> None:
+    """Bump `lile_queue_dropped_total{reason}` — reason in {full, shutdown}."""
+    _QUEUE_DROPPED.labels(reason=reason).inc()
+
+
+def record_replay_enqueued(n: int = 1) -> None:
+    """Bump `lile_replay_enqueued_total` by n (called by IdleReplayScheduler)."""
+    if n <= 0:
+        return
+    _REPLAY_ENQUEUED.inc(n)
+
+
+def record_generate_latency(*, stream: bool, latency_s: float) -> None:
+    """Observe `lile_generate_latency_ms{stream}`. For streams this is TTFT."""
+    _GENERATE_LATENCY.labels(stream="true" if stream else "false").observe(
+        latency_s * 1000.0
+    )
+
+
+# ---------------------------------------------------------------- middleware
+
+
+class MetricsMiddleware(BaseHTTPMiddleware):
+    """Bump `lile_requests_total{route, status}` once per response.
+
+    Uses ``request.scope["route"].path`` when FastAPI has resolved a route,
+    otherwise falls back to the raw path (so `/metrics` scrapes show up
+    correctly even before routing).
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        super().__init__(app)
+
+    async def dispatch(self, request: Request, call_next):
+        try:
+            response: Response = await call_next(request)
+            status = response.status_code
+        except Exception:
+            # Let exception handlers format the envelope; count as 500.
+            _REQUESTS.labels(
+                route=_resolve_route(request), status="500",
+            ).inc()
+            raise
+        _REQUESTS.labels(route=_resolve_route(request), status=str(status)).inc()
+        return response
+
+
+def _resolve_route(request: Request) -> str:
+    route = request.scope.get("route")
+    path = getattr(route, "path", None)
+    if path:
+        return path
+    # Fallback for unmatched routes (404 on unknown path).
+    return request.url.path or "unknown"

--- a/lile/server.py
+++ b/lile/server.py
@@ -13,12 +13,14 @@ from typing import Any
 
 import uvicorn
 from fastapi import FastAPI, HTTPException
-from fastapi.responses import StreamingResponse
+from fastapi.responses import Response, StreamingResponse
 from pydantic import BaseModel, Field
 
+from . import metrics as metrics_mod
 from .config import ServeConfig
 from .controller import Controller
 from .errors import NotFoundError
+from .metrics import MetricsMiddleware
 from .middleware import RequestIDMiddleware, current_request_id
 from .server_errors import register_error_handlers
 
@@ -101,6 +103,11 @@ def create_app(cfg: ServeConfig | None = None) -> FastAPI:
     app = FastAPI(title="lile", version="0.1.0-dev")
     app.state.cfg = cfg
     app.state.controller = Controller(cfg)
+    metrics_mod.bind_controller(app.state.controller)
+    # Middleware order: Starlette runs the outermost `add_middleware` last on
+    # the way in, first on the way out. We want MetricsMiddleware to see the
+    # final response status, so it goes outside RequestIDMiddleware.
+    app.add_middleware(MetricsMiddleware)
     app.add_middleware(RequestIDMiddleware)
     register_error_handlers(app)
 
@@ -111,6 +118,14 @@ def create_app(cfg: ServeConfig | None = None) -> FastAPI:
     @app.on_event("shutdown")
     async def _shutdown() -> None:
         await app.state.controller.stop()
+
+    # --------------------------------------------------------------- metrics
+    @app.get("/metrics")
+    async def metrics_endpoint() -> Response:
+        return Response(
+            metrics_mod.render_prometheus(),
+            media_type="text/plain; version=0.0.4; charset=utf-8",
+        )
 
     # --------------------------------------------------------------- health
     @app.get("/health")
@@ -133,6 +148,7 @@ def create_app(cfg: ServeConfig | None = None) -> FastAPI:
 
         if req.stream:
             async def sse():
+                ttft_observed = False
                 try:
                     async for ev in c.stream_generate(
                         messages,
@@ -184,6 +200,11 @@ def create_app(cfg: ServeConfig | None = None) -> FastAPI:
                         if len(delta_obj) == 1:
                             # Only role — nothing useful to emit.
                             continue
+                        if not ttft_observed:
+                            metrics_mod.record_generate_latency(
+                                stream=True, latency_s=time.time() - t0,
+                            )
+                            ttft_observed = True
                         payload = {
                             "id": ev["response_id"],
                             "object": "chat.completion.chunk",
@@ -222,6 +243,7 @@ def create_app(cfg: ServeConfig | None = None) -> FastAPI:
             parse_reasoning=req.parse_reasoning,
         )
         latency = time.time() - t0
+        metrics_mod.record_generate_latency(stream=False, latency_s=latency)
         message: dict[str, Any] = {"role": "assistant",
                                    "content": result["response"]}
         if result.get("reasoning_content"):

--- a/lile/tests/test_metrics.py
+++ b/lile/tests/test_metrics.py
@@ -1,0 +1,296 @@
+"""Prometheus metrics — registry shape, gauge sampling, counter hooks.
+
+Covers `lile/metrics.py`:
+
+- Counters (requests_total, train_steps_total, feedback_events_total,
+  queue_dropped_total, replay_enqueued_total).
+- Histograms (step_latency_ms, generate_latency_ms, objective_loss).
+- Lazy gauges (queue_depth, commit_cursor, merges_applied, trajectory_bytes,
+  snapshots_bytes, snapshots_count, shutting_down) sampled from a bound
+  Controller-shaped object at scrape time.
+- `render_prometheus()` returns valid OpenMetrics/Prometheus text exposition
+  format bytes.
+
+Run with: pytest lile/tests/test_metrics.py
+"""
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.cpu_only
+
+
+# ---------------------------------------------------------------- fixtures
+
+
+class _FakeQueue:
+    def __init__(self, *, qsize: int = 0, committed: int = 0) -> None:
+        self._q = type("_Q", (), {"qsize": lambda self: qsize})()
+        self.committed = committed
+
+
+class _FakeState:
+    def __init__(self, *, merges_applied: int = 0) -> None:
+        self.merges_applied = merges_applied
+
+
+class _FakeTrajectory:
+    def __init__(self, *, size: int = 0) -> None:
+        self._size = size
+
+    def size(self) -> int:
+        return self._size
+
+
+class _FakeController:
+    """Shape-compatible stand-in for the gauge sampler.
+
+    Exposes the attributes the gauge collector reads: ``queue``, ``state``,
+    ``trajectory``, ``snapshots.root``, ``_shutting_down`` (optional).
+    """
+
+    def __init__(
+        self,
+        *,
+        qsize: int = 0,
+        committed: int = 0,
+        merges: int = 0,
+        traj_bytes: int = 0,
+        snapshots_root=None,
+        shutting_down: bool = False,
+    ) -> None:
+        self.queue = _FakeQueue(qsize=qsize, committed=committed)
+        self.state = _FakeState(merges_applied=merges)
+        self.trajectory = _FakeTrajectory(size=traj_bytes)
+        self.snapshots = type("_S", (), {"root": snapshots_root})()
+        self._shutting_down = shutting_down
+
+
+# ---------------------------------------------------------------- module shape
+
+
+def test_module_exposes_render_prometheus_and_registry():
+    from lile import metrics
+
+    assert hasattr(metrics, "render_prometheus")
+    assert hasattr(metrics, "REGISTRY")
+    assert hasattr(metrics, "bind_controller")
+    assert hasattr(metrics, "record_request")
+    assert hasattr(metrics, "record_train_step")
+    assert hasattr(metrics, "record_feedback_event")
+    assert hasattr(metrics, "record_generate_latency")
+
+
+def test_render_prometheus_returns_bytes_with_text_format_header():
+    from lile import metrics
+
+    out = metrics.render_prometheus()
+    assert isinstance(out, (bytes, bytearray))
+    text = bytes(out).decode("utf-8")
+    # Every metric family is emitted with a `# HELP` and `# TYPE` line.
+    assert "# HELP lile_requests_total" in text
+    assert "# TYPE lile_requests_total counter" in text
+    assert "# HELP lile_queue_depth" in text
+    assert "# TYPE lile_queue_depth gauge" in text
+
+
+# ---------------------------------------------------------------- counters
+
+
+def test_record_request_increments_counter():
+    from lile import metrics
+
+    before = _counter_value(metrics.render_prometheus(),
+                            "lile_requests_total",
+                            {"route": "/v1/train", "status": "200"})
+    metrics.record_request(route="/v1/train", status=200)
+    after = _counter_value(metrics.render_prometheus(),
+                           "lile_requests_total",
+                           {"route": "/v1/train", "status": "200"})
+    assert after == before + 1.0
+
+
+def test_record_train_step_increments_counter_and_histogram():
+    from lile import metrics
+
+    before = _counter_value(metrics.render_prometheus(),
+                            "lile_train_steps_total", {"objective": "sft"})
+    metrics.record_train_step(objective="sft", latency_s=0.123, loss=1.5)
+    text = metrics.render_prometheus().decode("utf-8")
+    after = _counter_value(text.encode(), "lile_train_steps_total", {"objective": "sft"})
+    assert after == before + 1.0
+    # Histogram count bumped.
+    assert "lile_step_latency_ms_count" in text
+
+
+def test_record_feedback_event_counter():
+    from lile import metrics
+
+    before = _counter_value(metrics.render_prometheus(),
+                            "lile_feedback_events_total", {"kind": "binary"})
+    metrics.record_feedback_event(kind="binary")
+    after = _counter_value(metrics.render_prometheus(),
+                           "lile_feedback_events_total", {"kind": "binary"})
+    assert after == before + 1.0
+
+
+def test_record_generate_latency_observes_histogram():
+    from lile import metrics
+
+    metrics.record_generate_latency(stream=False, latency_s=0.25)
+    metrics.record_generate_latency(stream=True, latency_s=0.05)
+    text = metrics.render_prometheus().decode("utf-8")
+    assert 'lile_generate_latency_ms_count{stream="false"}' in text
+    assert 'lile_generate_latency_ms_count{stream="true"}' in text
+
+
+# ---------------------------------------------------------------- gauges (lazy)
+
+
+def test_gauge_collector_samples_live_state(tmp_path):
+    from lile import metrics
+
+    # Put two fake snapshot dirs on disk so the snapshots gauges are non-zero.
+    snap_root = tmp_path / "snapshots"
+    (snap_root / "v1").mkdir(parents=True)
+    (snap_root / "v2").mkdir()
+    (snap_root / "v1" / "x.bin").write_bytes(b"0" * 100)
+
+    ctrl = _FakeController(
+        qsize=3,
+        committed=42,
+        merges=7,
+        traj_bytes=1024,
+        snapshots_root=snap_root,
+        shutting_down=False,
+    )
+    metrics.bind_controller(ctrl)
+    text = metrics.render_prometheus().decode("utf-8")
+
+    assert _sample_value(text, "lile_queue_depth") == 3.0
+    assert _sample_value(text, "lile_commit_cursor") == 42.0
+    assert _sample_value(text, "lile_merges_applied") == 7.0
+    assert _sample_value(text, "lile_trajectory_bytes") == 1024.0
+    assert _sample_value(text, "lile_snapshots_count") == 2.0
+    assert _sample_value(text, "lile_snapshots_bytes") == 100.0
+    assert _sample_value(text, "lile_shutting_down") == 0.0
+
+
+def test_shutting_down_gauge_flips_when_flag_set(tmp_path):
+    from lile import metrics
+
+    ctrl = _FakeController(snapshots_root=tmp_path, shutting_down=True)
+    metrics.bind_controller(ctrl)
+    text = metrics.render_prometheus().decode("utf-8")
+    assert _sample_value(text, "lile_shutting_down") == 1.0
+
+
+def test_unbound_gauges_emit_zero(tmp_path):
+    from lile import metrics
+
+    # Reset any bound controller.
+    metrics.bind_controller(None)
+    text = metrics.render_prometheus().decode("utf-8")
+    # Gauges are still declared (text appears) but samples are zero.
+    assert _sample_value(text, "lile_queue_depth") == 0.0
+    assert _sample_value(text, "lile_shutting_down") == 0.0
+
+
+# ---------------------------------------------------------------- /metrics route
+
+
+def test_metrics_route_emits_prom_text_format():
+    from fastapi.testclient import TestClient
+
+    from lile.server_errors import register_error_handlers
+
+    # We mount just the /metrics route on a bare app to avoid loading a
+    # model. The real route lives in server.py and is identical in shape.
+    from fastapi import FastAPI
+    from fastapi.responses import Response
+
+    from lile import metrics
+
+    app = FastAPI()
+    register_error_handlers(app)
+
+    @app.get("/metrics")
+    async def _metrics():  # pragma: no cover — handler body checked via client
+        return Response(metrics.render_prometheus(),
+                        media_type="text/plain; version=0.0.4; charset=utf-8")
+
+    with TestClient(app) as client:
+        r = client.get("/metrics")
+
+    assert r.status_code == 200
+    assert r.headers["content-type"].startswith("text/plain")
+    assert r.text.startswith("#") or r.text.lstrip().startswith("#")
+    assert "lile_requests_total" in r.text
+
+
+def test_metrics_route_wired_in_server():
+    """The real server.py must expose /metrics. Checked without triggering
+    startup so we don't load a model in a cpu_only test."""
+    import pathlib
+    import tempfile
+
+    from lile.config import ServeConfig
+    from lile.server import create_app
+
+    cfg = ServeConfig(data_dir=pathlib.Path(tempfile.mkdtemp(prefix="lile_m_")))
+    app = create_app(cfg)
+    # Enumerate registered paths without entering a TestClient context, which
+    # would fire the startup event and call Controller.start → model load.
+    paths = [r.path for r in app.routes if hasattr(r, "path")]
+    assert "/metrics" in paths
+
+
+# ---------------------------------------------------------------- helpers
+
+
+def _counter_value(rendered: bytes, name: str, labels: dict[str, str]) -> float:
+    """Parse a single counter sample out of the rendered text format."""
+    text = rendered.decode("utf-8") if isinstance(rendered, (bytes, bytearray)) else rendered
+    # prometheus_client emits both `<name>` (current) and `<name>_total` for
+    # counters, depending on version. Accept either.
+    return max(
+        _sample_value(text, name, labels),
+        _sample_value(text, name + "_created" if name.endswith("_total") else name, labels),
+        _sample_value(text, name[:-6] if name.endswith("_total") else name, labels),
+    )
+
+
+def _sample_value(text: str, name: str, labels: dict[str, str] | None = None) -> float:
+    """Return the sample value for ``<name>{<labels>} <value>`` or 0.0 if absent."""
+    label_str = ""
+    if labels:
+        # prom text format labels are alphabetized; match permissively by
+        # checking every `name{...}` line and parsing.
+        pass
+    best = 0.0
+    for line in text.splitlines():
+        if line.startswith("#"):
+            continue
+        if not line.startswith(name):
+            continue
+        # Split at first whitespace → "<name>{labels}" <value>
+        parts = line.rsplit(" ", 1)
+        if len(parts) != 2:
+            continue
+        label_part = parts[0]
+        try:
+            value = float(parts[1])
+        except ValueError:
+            continue
+        if labels:
+            if not all(f'{k}="{v}"' in label_part for k, v in labels.items()):
+                continue
+            # Tighten: name must exactly match the prefix before `{`.
+            prefix = label_part.split("{", 1)[0]
+            if prefix != name:
+                continue
+        else:
+            if label_part != name:
+                continue
+        best = value  # take last occurrence — prom_client emits one sample per line
+    return best

--- a/studio/backend/requirements/studio.txt
+++ b/studio/backend/requirements/studio.txt
@@ -3,6 +3,7 @@ typer
 fastapi
 uvicorn
 pydantic
+prometheus-client
 matplotlib
 pandas
 nest_asyncio


### PR DESCRIPTION
## Summary

Closes #13. Adds a pull-based `/metrics` surface in Prometheus text format. Grafana / Prometheus / VictoriaMetrics can now scrape queue depth, commit cursor, merge count, trajectory/snapshot disk usage, per-route request counts, train-step latency/loss distributions, and more.

**Stacked on #19 (structured errors)** — the request counter hooks ride on the same middleware stack. Rebase onto `ht` after #19 merges.

## Metrics

### Gauges (lazy, sampled at scrape time from the live Controller)
- `lile_queue_depth`
- `lile_commit_cursor`
- `lile_merges_applied`
- `lile_trajectory_bytes`
- `lile_snapshots_count`
- `lile_snapshots_bytes`
- `lile_shutting_down` — forward-compat for #11's shutdown flag

### Counters
- `lile_requests_total{route,status}` — bumped by `MetricsMiddleware`
- `lile_train_steps_total{objective}`
- `lile_feedback_events_total{kind}`
- `lile_queue_dropped_total{reason}` — hook exists, wired up in #11
- `lile_replay_enqueued_total`

### Histograms
- `lile_step_latency_ms{objective}` — 5ms–30s buckets
- `lile_generate_latency_ms{stream}` — non-stream total, stream TTFT
- `lile_objective_loss{objective}` — LLM NLL range buckets

## What changed

- **`lile/metrics.py`** — private `CollectorRegistry`, metric families, lazy `_ControllerGaugeCollector`, `MetricsMiddleware`, hot-path hooks.
- **`lile/server.py`** — `GET /metrics` returning `text/plain; version=0.0.4`; middleware stack; `record_generate_latency` on both paths (TTFT for streams).
- **`lile/controller.py`** — `record_train_step` in `_handle_task`; `record_feedback_event` in `submit_feedback`.

## Tests

11 new cpu_only cases pinning:
- Counter/histogram increment semantics.
- Lazy gauge sampling from a fake Controller (qsize, committed, merges_applied, trajectory size, walked snapshots dir size+count, shutting_down flag).
- Unbound gauges emit zero (well-defined during startup / in tests).
- Text exposition format (`# HELP` / `# TYPE` / samples).
- `/metrics` route registered on the real `create_app` (no startup, no model).

Full cpu_only suite: **66 passed**.

## Non-goals / follow-ups

- `lile_queue_dropped_total{reason}` is defined but incremented only when #11 lands the shutdown drain path.
- Auth wrap: `/metrics` is unauthenticated for now; wrap with #16 when auth lands.
- Bucket tuning is first-pass — revisit after real production scrapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)