### PR TITLE
fix(studio): harden /api/lile proxy + gate trajectory poll

### DIFF
--- a/studio/backend/routes/lile.py
+++ b/studio/backend/routes/lile.py
@@ -207,8 +207,11 @@ async def proxy(path: str, request: Request):
                         status_code=upstream.status_code,
                         headers=rh,
                         media_type=upstream.headers.get("content-type"))
-    except (httpx.ConnectError, httpx.ReadError):
+    except httpx.HTTPError as exc:
         return Response(
-            content=json.dumps({"error": "proxy upstream failure"}),
+            content=json.dumps({
+                "error": "proxy upstream failure",
+                "detail": f"{type(exc).__name__}: {exc}",
+            }),
             status_code=502, media_type="application/json",
         )

--- a/studio/frontend/src/features/lile/lile-page.tsx
+++ b/studio/frontend/src/features/lile/lile-page.tsx
@@ -23,9 +23,8 @@ import { useLileCapsuleStore } from "@/features/lile/stores/lile-capsule-store";
 
 export function LilePage(): ReactElement {
   useLileStatusPoll({ enabled: true });
-  useLileTrajectoryPoll({ enabled: true });
-
   const status = useLileCapsuleStore((s) => s.status);
+  useLileTrajectoryPoll({ enabled: status?.running === true });
 
   return (
     <div className="flex flex-col gap-4 p-4">


### PR DESCRIPTION
## Summary
- Proxy now catches the full `httpx.HTTPError` hierarchy, not just `ConnectError`/`ReadError`. `RemoteProtocolError` (e.g. port held by a non-lile service) no longer bubbles up as 500.
- 502 body now includes `detail: "<ExceptionClass>: <message>"` for diagnosability.
- Trajectory poll is now gated on `status?.running === true` so it stops spamming 502s before the capsule is up.

## Test plan
- [x] Start Studio with no lile daemon — no 502 spam, trajectory poll idle
- [x] Start lile daemon on a different port and point Studio at it — traffic flows, stream stays open
- [x] Simulate port held by another service — 502 surfaces the upstream class/message cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)