### PR TITLE
feat(lile/studio): signal-strength knob on Chat SFT card

### DIFF
--- a/studio/frontend/src/features/lile/components/train-tab/chat-sft-card.test.tsx
+++ b/studio/frontend/src/features/lile/components/train-tab/chat-sft-card.test.tsx
@@ -43,4 +43,35 @@ describe("ChatSftCard", () => {
 
     spy.mockRestore();
   });
+
+  it("switches to weighted_sft when strength is not 1.0", async () => {
+    const spy = spyOn(lileClient, "postTrain").mockImplementation(() =>
+      Promise.resolve({ queued: true }),
+    );
+
+    render(<ChatSftCard />);
+
+    fireEvent.change(screen.getByLabelText(/user/i), { target: { value: "hi" } });
+    fireEvent.change(screen.getByLabelText(/assistant/i), { target: { value: "hello" } });
+    fireEvent.change(screen.getByLabelText(/strength/i), { target: { value: "3" } });
+
+    fireEvent.click(screen.getByRole("button", { name: /train/i }));
+
+    await waitFor(() => expect(spy.mock.calls.length).toBe(1));
+
+    expect(spy.mock.calls[0][0]).toMatchObject({
+      objective: "weighted_sft",
+      samples: [
+        {
+          weight: 3,
+          messages: [
+            { role: "user", content: "hi" },
+            { role: "assistant", content: "hello" },
+          ],
+        },
+      ],
+    });
+
+    spy.mockRestore();
+  });
 });

--- a/studio/frontend/src/features/lile/components/train-tab/chat-sft-card.tsx
+++ b/studio/frontend/src/features/lile/components/train-tab/chat-sft-card.tsx
@@ -5,6 +5,7 @@ import type { FormEvent, ReactElement } from "react";
 import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { lileClient } from "../../api/lile-client";
@@ -19,6 +20,7 @@ const defaultRows: Row[] = [
 
 export function ChatSftCard(): ReactElement {
   const [rows, setRows] = useState<Row[]>(defaultRows);
+  const [weight, setWeight] = useState(1.0);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -41,9 +43,12 @@ export function ChatSftCard(): ReactElement {
     setSubmitting(true);
     setError(null);
     try {
+      const objective = weight === 1.0 ? "sft" : "weighted_sft";
+      const sample: { messages: Row[]; weight?: number } = { messages: rows };
+      if (objective === "weighted_sft") sample.weight = weight;
       await lileClient.postTrain({
-        objective: "sft",
-        samples: [{ messages: rows }],
+        objective,
+        samples: [sample],
       });
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
@@ -105,10 +110,26 @@ export function ChatSftCard(): ReactElement {
         })}
       </div>
 
-      <div className="flex gap-2">
+      <div className="flex items-center gap-2">
         <Button type="button" variant="outline" onClick={addTurn} disabled={submitting}>
           Add turn
         </Button>
+        <div className="flex-1" />
+        <Label htmlFor="sft-weight" className="text-xs text-muted-foreground">
+          strength
+        </Label>
+        <Input
+          id="sft-weight"
+          type="number"
+          min={0.1}
+          max={10}
+          step="any"
+          value={weight}
+          onChange={(e) => setWeight(Number.parseFloat(e.target.value) || 1.0)}
+          disabled={submitting}
+          className="w-20"
+          aria-label="Training sample strength (weight)"
+        />
         <Button type="submit" disabled={submitting}>
           {submitting ? "Training…" : "Train"}
         </Button>


### PR DESCRIPTION
## Summary
- Adds a `strength` numeric input to the Studio Chat SFT card, mirroring the weight control in `lile/console/demo.html`.
- At `1.0` the objective stays `sft`; any other value switches to `weighted_sft` with the weight attached to the sample.
- Uses `step="any"` so integer inputs like `3` don't trip HTML5 number validation.

Lets the operator express "this sample is worth N iterations" without bouncing through the advanced-JSON panel. Aligned with `sample-efficiency-synthesis.md` S1.

## Test plan
- [x] `chat-sft-card.test.tsx` — 2 tests pass (plain SFT + weighted path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)