### PR TITLE
feat(lile): shutdown follow-ups — configurable hard-stop grace + lifespan

### DIFF
--- a/lile/config.py
+++ b/lile/config.py
@@ -26,6 +26,14 @@ class ServeConfig:
     # with ``ShutdownDroppedError`` — so no ``wait_for(token)`` ever hangs.
     shutdown_deadline_s: float = 30.0
 
+    # Extra grace after the deadline expires with a still-running in-flight
+    # task. We never cancel mid-GPU-step (would tear the LoRA), so the queue
+    # worker needs a bounded post-deadline window to finish. Operators should
+    # size ``shutdown_deadline_s + shutdown_hard_stop_grace_s`` to stay under
+    # ``terminationGracePeriodSeconds`` on k8s — otherwise the pod is
+    # SIGKILLed mid-flight regardless of the graceful path.
+    shutdown_hard_stop_grace_s: float = 30.0
+
     default_lr: float = 1e-5
     default_objective: str = "sft"
 

--- a/lile/controller.py
+++ b/lile/controller.py
@@ -105,7 +105,12 @@ class Controller:
         except Exception as exc:  # pragma: no cover
             log.warning("metrics_logger close failed: %s", exc)
 
-    async def graceful_shutdown(self, deadline_s: float | None = 30.0) -> dict[str, Any]:
+    async def graceful_shutdown(
+        self,
+        deadline_s: float | None = 30.0,
+        *,
+        hard_stop_grace_s: float = 30.0,
+    ) -> dict[str, Any]:
         """Drain the queue with a deadline, then release resources.
 
         Ordered so that no new work lands after the flag flips:
@@ -117,7 +122,10 @@ class Controller:
         3. Delegate the queue drain to :meth:`ComputeQueue.graceful_drain`
            (closes the queue, lets in-flight finish, resolves remainders
            with :class:`ShutdownDroppedError` so every ``wait_for`` caller
-           gets a deterministic result).
+           gets a deterministic result). ``hard_stop_grace_s`` bounds the
+           post-deadline window for the in-flight task so operators can size
+           the total shutdown budget against k8s's
+           ``terminationGracePeriodSeconds``.
         4. Close the metrics logger (swallow errors — logger is optional).
 
         Idempotent — a second call returns immediately with
@@ -129,7 +137,10 @@ class Controller:
         if self._replay is not None:
             await self._replay.stop()
             self._replay = None
-        drain = await self.queue.graceful_drain(deadline_s=deadline_s)
+        drain = await self.queue.graceful_drain(
+            deadline_s=deadline_s,
+            hard_stop_grace_s=hard_stop_grace_s,
+        )
         try:
             self.metrics_logger.close()
         except Exception as exc:  # pragma: no cover — logger is optional

--- a/lile/queue.py
+++ b/lile/queue.py
@@ -164,7 +164,12 @@ class ComputeQueue:
             await self._worker_task
             self._worker_task = None
 
-    async def graceful_drain(self, deadline_s: float | None = None) -> dict[str, Any]:
+    async def graceful_drain(
+        self,
+        deadline_s: float | None = None,
+        *,
+        hard_stop_grace_s: float = 30.0,
+    ) -> dict[str, Any]:
         """Close the queue, drain pending, resolve remainders with ShutdownDropped.
 
         On entry: flip ``_accepting`` so any new ``submit`` raises
@@ -181,6 +186,10 @@ class ComputeQueue:
         and every still-pending queue entry gets ``error =
         ShutdownDroppedError`` and ``done.set()`` so every ``wait_for``
         caller resolves deterministically.
+
+        ``hard_stop_grace_s`` bounds how long we'll wait for the in-flight
+        task after setting ``_hard_stop``. k8s operators should size this
+        plus ``deadline_s`` to stay under ``terminationGracePeriodSeconds``.
 
         Idempotent: a second call with nothing left to do returns
         ``{"dropped": 0, "timed_out": False}``.
@@ -205,7 +214,8 @@ class ComputeQueue:
             self._hard_stop.set()
             try:
                 await asyncio.wait_for(
-                    asyncio.shield(self._worker_task), timeout=30.0,
+                    asyncio.shield(self._worker_task),
+                    timeout=hard_stop_grace_s,
                 )
             except asyncio.TimeoutError:
                 # In-flight task is genuinely stuck; best we can do is move

--- a/lile/server.py
+++ b/lile/server.py
@@ -100,7 +100,24 @@ class SnapshotRequest(BaseModel):
 # ---------------------------------------------------------------------- app
 def create_app(cfg: ServeConfig | None = None) -> FastAPI:
     cfg = cfg or ServeConfig()
-    app = FastAPI(title="lile", version="0.1.0-dev")
+
+    @contextlib.asynccontextmanager
+    async def lifespan(app: FastAPI):
+        # Startup — Controller was constructed below (pre-lifespan) so routes
+        # can close over it without waiting for this hook.
+        await app.state.controller.start()
+        try:
+            yield
+        finally:
+            # Prefer the graceful path so pending /v1/wait callers get
+            # ShutdownDroppedError envelopes instead of hanging on their own
+            # 60s timeout (see issue #11).
+            await app.state.controller.graceful_shutdown(
+                deadline_s=cfg.shutdown_deadline_s,
+                hard_stop_grace_s=cfg.shutdown_hard_stop_grace_s,
+            )
+
+    app = FastAPI(title="lile", version="0.1.0-dev", lifespan=lifespan)
     app.state.cfg = cfg
     app.state.controller = Controller(cfg)
     metrics_mod.bind_controller(app.state.controller)
@@ -110,19 +127,6 @@ def create_app(cfg: ServeConfig | None = None) -> FastAPI:
     app.add_middleware(MetricsMiddleware)
     app.add_middleware(RequestIDMiddleware)
     register_error_handlers(app)
-
-    @app.on_event("startup")
-    async def _startup() -> None:
-        await app.state.controller.start()
-
-    @app.on_event("shutdown")
-    async def _shutdown() -> None:
-        # Prefer the graceful path so pending /v1/wait callers get
-        # ShutdownDroppedError envelopes instead of hanging on their own
-        # 60s timeout (see issue #11).
-        await app.state.controller.graceful_shutdown(
-            deadline_s=cfg.shutdown_deadline_s,
-        )
 
     # --------------------------------------------------------------- metrics
     @app.get("/metrics")

--- a/lile/tests/_sigterm_target.py
+++ b/lile/tests/_sigterm_target.py
@@ -1,0 +1,77 @@
+"""Subprocess target for ``test_sigterm_lifespan.py``.
+
+Runs a FastAPI app with the same lifespan wiring as :mod:`lile.server` but
+with a stub Controller that never loads a model. When lifespan exits (SIGTERM
+from the parent test), the stub writes a sentinel file so the parent can
+assert that ``graceful_shutdown`` was invoked with the expected arguments.
+
+Driven entirely by env vars so the parent test controls everything:
+
+- ``LILE_SIGTERM_SENTINEL`` — path to write on graceful_shutdown
+- ``LILE_SIGTERM_PORT`` — port to bind
+- ``LILE_SIGTERM_DEADLINE`` — ``shutdown_deadline_s`` to pass (default 5.0)
+- ``LILE_SIGTERM_GRACE`` — ``shutdown_hard_stop_grace_s`` to pass (default 5.0)
+"""
+from __future__ import annotations
+
+import contextlib
+import os
+from pathlib import Path
+
+import uvicorn
+from fastapi import FastAPI
+
+
+class _StubController:
+    def __init__(self, sentinel: Path) -> None:
+        self.sentinel = sentinel
+
+    async def start(self) -> None:
+        pass
+
+    async def graceful_shutdown(
+        self,
+        deadline_s: float = 30.0,
+        *,
+        hard_stop_grace_s: float = 30.0,
+    ) -> dict:
+        self.sentinel.write_text(
+            f"graceful_shutdown deadline={deadline_s} grace={hard_stop_grace_s}"
+        )
+        return {
+            "already_shut_down": False,
+            "dropped": 0,
+            "timed_out": False,
+        }
+
+
+def main() -> None:
+    sentinel = Path(os.environ["LILE_SIGTERM_SENTINEL"])
+    port = int(os.environ["LILE_SIGTERM_PORT"])
+    deadline = float(os.environ.get("LILE_SIGTERM_DEADLINE", "5.0"))
+    hard_stop_grace = float(os.environ.get("LILE_SIGTERM_GRACE", "5.0"))
+
+    stub = _StubController(sentinel)
+
+    @contextlib.asynccontextmanager
+    async def lifespan(app: FastAPI):
+        await stub.start()
+        try:
+            yield
+        finally:
+            await stub.graceful_shutdown(
+                deadline_s=deadline,
+                hard_stop_grace_s=hard_stop_grace,
+            )
+
+    app = FastAPI(lifespan=lifespan)
+
+    @app.get("/health")
+    async def health() -> dict:
+        return {"ok": True}
+
+    uvicorn.run(app, host="127.0.0.1", port=port, log_level="warning")
+
+
+if __name__ == "__main__":
+    main()

--- a/lile/tests/test_graceful_shutdown.py
+++ b/lile/tests/test_graceful_shutdown.py
@@ -198,19 +198,19 @@ def test_in_flight_pending_tasks_resolve_with_shutdown_dropped(tmp_path):
 # ---------------------------------------------------------------- server.py
 
 
-def test_server_startup_wires_shutdown_hook(tmp_path, monkeypatch):
-    """The FastAPI shutdown event must call ``controller.graceful_shutdown``
-    rather than the legacy abrupt ``stop``. Enumerate the registered event
-    handlers without spinning up a Controller or a model."""
+def test_server_wires_lifespan(tmp_path):
+    """Startup + shutdown are handled by a FastAPI lifespan context manager,
+    which calls ``controller.graceful_shutdown`` on exit. We enumerate the
+    router config without spinning up a Controller or a model (behavior is
+    covered by the Controller-level tests above)."""
     from lile.config import ServeConfig
     from lile.server import create_app
 
     cfg = ServeConfig(data_dir=tmp_path)
     app = create_app(cfg)
-    handlers = app.router.on_shutdown
-    # There's a single shutdown handler — the one we register.
-    assert len(handlers) >= 1
-    # It's an async function named `_shutdown` in server.py — we don't
-    # want to load the model, so just check it's wired; behavior is covered
-    # by the Controller-level tests above.
-    assert any(getattr(h, "__name__", "") == "_shutdown" for h in handlers)
+    # Lifespan replaces the legacy on_startup/on_shutdown callbacks, so the
+    # router's event-handler lists should be empty.
+    assert app.router.on_startup == []
+    assert app.router.on_shutdown == []
+    # The lifespan context manager is bound on the router.
+    assert app.router.lifespan_context is not None

--- a/lile/tests/test_sigterm_lifespan.py
+++ b/lile/tests/test_sigterm_lifespan.py
@@ -1,0 +1,90 @@
+"""End-to-end SIGTERM → lifespan → graceful_shutdown test.
+
+Pins the signal-delivery contract flagged as missing in #28 review: uvicorn
+must translate SIGTERM into a clean lifespan exit, and that exit must await
+:meth:`Controller.graceful_shutdown` with the configured deadline + grace.
+
+Uses a subprocess target (``_sigterm_target.py``) that stubs the Controller
+so we don't load a GPU model in a cpu_only test. The target writes a sentinel
+file when ``graceful_shutdown`` fires; the test asserts it ran with the
+expected kwargs and that the subprocess exited cleanly (rc==0).
+"""
+from __future__ import annotations
+
+import os
+import signal
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import httpx
+import pytest
+
+pytestmark = pytest.mark.cpu_only
+
+
+def _free_port() -> int:
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def _wait_healthy(port: int, timeout_s: float = 15.0) -> None:
+    deadline = time.time() + timeout_s
+    last_err: Exception | None = None
+    while time.time() < deadline:
+        try:
+            r = httpx.get(f"http://127.0.0.1:{port}/health", timeout=0.5)
+            if r.status_code == 200:
+                return
+        except httpx.HTTPError as exc:
+            last_err = exc
+        time.sleep(0.1)
+    raise TimeoutError(
+        f"daemon on port {port} did not become healthy (last: {last_err!r})"
+    )
+
+
+def test_sigterm_fires_graceful_shutdown(tmp_path):
+    sentinel = tmp_path / "sentinel"
+    port = _free_port()
+    env = dict(
+        os.environ,
+        LILE_SIGTERM_SENTINEL=str(sentinel),
+        LILE_SIGTERM_PORT=str(port),
+        LILE_SIGTERM_DEADLINE="5.0",
+        LILE_SIGTERM_GRACE="3.0",
+    )
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "lile.tests._sigterm_target"],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        _wait_healthy(port)
+        proc.send_signal(signal.SIGTERM)
+        rc = proc.wait(timeout=15.0)
+        out, err = proc.communicate(timeout=1.0)
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=5.0)
+
+    # The sentinel content is the real contract — it proves the lifespan ran
+    # graceful_shutdown with the expected kwargs. uvicorn's default signal
+    # handler propagates SIGTERM back to the process after the lifespan
+    # completes (rc == -SIGTERM), so accept either disposition.
+    assert rc in (0, -signal.SIGTERM), (
+        f"subprocess exited with rc={rc}\n"
+        f"stdout: {out.decode(errors='replace')}\n"
+        f"stderr: {err.decode(errors='replace')}"
+    )
+    assert sentinel.exists(), "graceful_shutdown sentinel was not written"
+    body = sentinel.read_text()
+    assert "deadline=5.0" in body, body
+    assert "grace=3.0" in body, body


### PR DESCRIPTION
## Summary

Addresses two #28 review follow-ups:

1. **Post-hard-stop grace is now configurable.** `ComputeQueue.graceful_drain` accepts `hard_stop_grace_s` (was hardcoded 30.0). `Controller.graceful_shutdown` plumbs it through from a new `ServeConfig.shutdown_hard_stop_grace_s`. Operators sizing against k8s `terminationGracePeriodSeconds` get a predictable upper bound (`deadline + grace`) instead of a silently-doubling effective deadline.

2. **`on_event` → lifespan.** Replaces the deprecated `@app.on_event("shutdown")` with a FastAPI lifespan context manager that calls `graceful_shutdown` on exit. Adds an end-to-end SIGTERM → lifespan subprocess test.

## Test plan

- [x] `test_queue_graceful_drain.py` / `test_graceful_shutdown.py` still green with the new keyword
- [x] New `test_sigterm_lifespan.py` spawns a subprocess with a stub Controller, sends SIGTERM, asserts the sentinel file written by `graceful_shutdown` contains the configured deadline + grace
- [x] Full cpu_only suite green (93 passed)

Notes on the SIGTERM test:
- Uses a `_sigterm_target.py` subprocess helper so no GPU model loads — stays cpu_only
- uvicorn's default signal handler propagates SIGTERM back after the lifespan completes, so the test accepts `rc in (0, -SIGTERM)`. The sentinel file (written inside `graceful_shutdown`) is the actual contract assertion: it proves the lifespan fired with the right kwargs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)