### PR TITLE
feat(lile): verifier registry — W2, unblocks PR L (TTRL)

### DIFF
--- a/lile/objectives/verifiers/__init__.py
+++ b/lile/objectives/verifiers/__init__.py
@@ -1,0 +1,83 @@
+"""Verifier registry — pass/fail (or graded) checks on candidate responses
+where an objective ground-truth exists.
+
+Consumed by TTRL-style pseudo-reward training (roadmap PR L) and future RL
+workstreams. A verifier answers one question:
+
+    Given ``prompt``, does ``candidate`` satisfy the domain-specific check?
+
+Return values:
+
+- ``True`` / ``1.0`` — candidate verifies cleanly
+- ``False`` / ``0.0`` — candidate fails the check
+- ``None`` — verifier is not applicable to this prompt (caller should skip;
+  ``None`` is never coerced to False downstream)
+
+Verifiers are adapters: they must never raise into the caller. The top-level
+:func:`verify` dispatcher catches any exception and returns ``None`` so a
+bad verifier can't take down the train loop.
+
+Registering a custom verifier:
+
+    from lile.objectives.verifiers import register
+
+    @register("my_domain")
+    def verify(prompt: str, candidate: str) -> bool | float | None:
+        ...
+"""
+from __future__ import annotations
+
+import logging
+from typing import Callable
+
+log = logging.getLogger(__name__)
+
+Verifier = Callable[[str, str], "bool | float | None"]
+
+# Populated at module import by the seed modules below.
+VERIFIERS: dict[str, Verifier] = {}
+
+
+def register(domain: str) -> Callable[[Verifier], Verifier]:
+    """Decorator that registers ``fn`` as the verifier for ``domain``."""
+    def _wrap(fn: Verifier) -> Verifier:
+        VERIFIERS[domain] = fn
+        return fn
+    return _wrap
+
+
+def verify(domain: str, prompt: str, candidate: str) -> bool | float | None:
+    """Dispatch to ``VERIFIERS[domain]``, swallowing adapter exceptions.
+
+    Returns ``None`` when no verifier is registered for ``domain`` or the
+    verifier itself raises — both indicate "can't judge this", never "fail".
+    """
+    fn = VERIFIERS.get(domain)
+    if fn is None:
+        return None
+    try:
+        return fn(prompt, candidate)
+    except Exception as exc:
+        log.warning("verifier %r raised %s — returning None", domain, exc)
+        return None
+
+
+def select(prompt: str) -> str | None:
+    """Return the first registered verifier whose domain claims ``prompt``.
+
+    Each seed verifier exposes a ``claims(prompt) -> bool`` sibling used here
+    to let TTRL pick a verifier without the caller hard-coding domains.
+    Custom verifiers without a ``claims`` attribute are skipped — register
+    your own ``select`` if you need richer routing.
+    """
+    for domain, fn in VERIFIERS.items():
+        claims = getattr(fn, "claims", None)
+        if callable(claims) and claims(prompt):
+            return domain
+    return None
+
+
+# Seed the registry. Order matters for :func:`select` — cheapest/strictest
+# claim first, so "math" wins over "code" on ambiguous prompts.
+from . import _math  # noqa: F401, E402
+from . import _code  # noqa: F401, E402

--- a/lile/objectives/verifiers/__init__.py
+++ b/lile/objectives/verifiers/__init__.py
@@ -69,6 +69,12 @@ def select(prompt: str) -> str | None:
     to let TTRL pick a verifier without the caller hard-coding domains.
     Custom verifiers without a ``claims`` attribute are skipped — register
     your own ``select`` if you need richer routing.
+
+    Dispatch is insertion-order over ``VERIFIERS``; the first claim wins.
+    Priority-sensitive verifiers (stricter claims that should pre-empt the
+    seeds) must insert into ``VERIFIERS`` at the head rather than appending
+    — e.g. ``VERIFIERS = {"my_strict": fn, **VERIFIERS}`` — or register
+    their own ``select`` wrapper.
     """
     for domain, fn in VERIFIERS.items():
         claims = getattr(fn, "claims", None)

--- a/lile/objectives/verifiers/_code.py
+++ b/lile/objectives/verifiers/_code.py
@@ -1,0 +1,97 @@
+"""Executable-subset Python verifier.
+
+Claims prompts whose last line looks like "Expected output: <...>". Verifies
+that the fenced Python block in the candidate, when run under a restricted
+``exec`` sandbox with a wall-clock budget, prints exactly the expected
+output.
+
+The sandbox is intentionally small: no ``__import__``, no filesystem, no
+network, no ``open``. It is **not** a security boundary — it's a cheap
+"does this candidate do the right thing" check for pseudo-reward training.
+For adversarial inputs (user-submitted code in prod), wrap this in a real
+sandbox (nsjail, firecracker). That wrapping is PR L's problem, not the
+registry's.
+"""
+from __future__ import annotations
+
+import io
+import re
+import signal
+from contextlib import redirect_stdout
+
+from . import register
+
+_EXPECTED = re.compile(r"(?i)\bexpected(?:\s+output)?\s*[:=]\s*(.+?)(?:\n|$)")
+_CODE_FENCE = re.compile(r"```(?:python)?\s*\n(.*?)```", re.DOTALL)
+_EXEC_TIMEOUT_S = 1
+
+
+class _ExecTimeout(Exception):
+    pass
+
+
+def _timeout_handler(signum, frame):  # pragma: no cover — signal path
+    raise _ExecTimeout()
+
+
+_SAFE_BUILTINS = {
+    name: __builtins__[name] if isinstance(__builtins__, dict) else getattr(__builtins__, name)
+    for name in (
+        "abs", "all", "any", "bool", "dict", "divmod", "enumerate", "filter",
+        "float", "int", "len", "list", "map", "max", "min", "print", "range",
+        "reversed", "round", "set", "sorted", "str", "sum", "tuple", "zip",
+    )
+}
+
+
+def extract_expected(prompt: str) -> str | None:
+    """Return the ``Expected:`` stanza from ``prompt`` (stripped), or None."""
+    m = _EXPECTED.search(prompt)
+    return m.group(1).strip() if m else None
+
+
+def extract_code(candidate: str) -> str | None:
+    """Return the first fenced Python block in ``candidate``, or None."""
+    m = _CODE_FENCE.search(candidate)
+    return m.group(1) if m else None
+
+
+def _run_sandboxed(code: str) -> str:
+    """Run ``code`` with restricted builtins and a wall-clock timeout.
+
+    Returns captured stdout on clean exit; raises on any error (caller
+    translates to a False verdict).
+    """
+    buf = io.StringIO()
+    ns = {"__builtins__": _SAFE_BUILTINS}
+    prev = signal.signal(signal.SIGALRM, _timeout_handler)
+    signal.alarm(_EXEC_TIMEOUT_S)
+    try:
+        with redirect_stdout(buf):
+            exec(code, ns, ns)
+    finally:
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, prev)
+    return buf.getvalue().strip()
+
+
+def claims(prompt: str) -> bool:
+    return extract_expected(prompt) is not None
+
+
+@register("code")
+def verify(prompt: str, candidate: str) -> bool | None:
+    expected = extract_expected(prompt)
+    if expected is None:
+        return None
+    code = extract_code(candidate)
+    if code is None:
+        return False
+    try:
+        got = _run_sandboxed(code)
+    except Exception:
+        return False
+    return got == expected
+
+
+verify.claims = claims  # type: ignore[attr-defined]

--- a/lile/objectives/verifiers/_code.py
+++ b/lile/objectives/verifiers/_code.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import io
 import re
 import signal
+import threading
 from contextlib import redirect_stdout
 
 from . import register
@@ -61,17 +62,29 @@ def _run_sandboxed(code: str) -> str:
 
     Returns captured stdout on clean exit; raises on any error (caller
     translates to a False verdict).
+
+    The SIGALRM wall-clock budget only arms on the main thread — Python's
+    ``signal.signal`` raises ``ValueError`` from any other thread. Worker-
+    thread callers (dataloader workers, asyncio executors, ComputeQueue
+    worker) lose the timeout guard; PR L is expected to swap this path
+    for ``multiprocessing.Process`` + ``.join(timeout=…)`` before accepting
+    adversarial candidates. The no-timeout fallback is acceptable for the
+    seed because every caller today runs against trusted candidates.
     """
     buf = io.StringIO()
     ns = {"__builtins__": _SAFE_BUILTINS}
-    prev = signal.signal(signal.SIGALRM, _timeout_handler)
-    signal.alarm(_EXEC_TIMEOUT_S)
+    armed = threading.current_thread() is threading.main_thread()
+    prev = None
+    if armed:
+        prev = signal.signal(signal.SIGALRM, _timeout_handler)
+        signal.alarm(_EXEC_TIMEOUT_S)
     try:
         with redirect_stdout(buf):
             exec(code, ns, ns)
     finally:
-        signal.alarm(0)
-        signal.signal(signal.SIGALRM, prev)
+        if armed:
+            signal.alarm(0)
+            signal.signal(signal.SIGALRM, prev)
     return buf.getvalue().strip()
 
 

--- a/lile/objectives/verifiers/_math.py
+++ b/lile/objectives/verifiers/_math.py
@@ -1,0 +1,64 @@
+"""GSM8K-style numeric-answer verifier.
+
+Claims prompts that look like arithmetic word problems (or any prompt
+containing a number plus a question verb). Verifies that the candidate
+response exposes a final, extractable numeric answer.
+
+Equivalence semantics are deliberately minimal here — the verifier only
+reports *extractability*. TTRL layers equivalence hashing on top by
+calling :func:`extract_answer` directly.
+"""
+from __future__ import annotations
+
+import re
+
+from . import register
+
+# Explicit boxed / labelled answer patterns, tried in order.
+_ANSWER_PATTERNS = (
+    re.compile(r"####\s*(-?\d[\d,]*(?:\.\d+)?)"),
+    re.compile(r"\\boxed\{\s*(-?\d[\d,]*(?:\.\d+)?)\s*\}"),
+    re.compile(r"(?i)\banswer(?:\s+is)?\s*[:=]?\s*(-?\d[\d,]*(?:\.\d+)?)"),
+)
+# Fallback: last number anywhere in the response.
+_NUMBER = re.compile(r"-?\d[\d,]*(?:\.\d+)?")
+
+# Cheap prompt classifier — question verb + a digit or arithmetic noun.
+_PROMPT_CLAIM = re.compile(
+    r"(?i)(how many|how much|what is|what's|find|compute|calculate|solve|"
+    r"sum of|product of|average|mean|total|percentage|fraction)",
+)
+
+
+def _normalize(s: str) -> str:
+    s = s.replace(",", "")
+    if "." in s:
+        s = s.rstrip("0").rstrip(".")
+    return s or "0"
+
+
+def extract_answer(text: str) -> str | None:
+    """Return the normalized final numeric answer in ``text`` or ``None``."""
+    for pat in _ANSWER_PATTERNS:
+        m = pat.search(text)
+        if m:
+            return _normalize(m.group(1))
+    matches = _NUMBER.findall(text)
+    if matches:
+        return _normalize(matches[-1])
+    return None
+
+
+def claims(prompt: str) -> bool:
+    """True when ``prompt`` looks like a math problem (heuristic)."""
+    return bool(_PROMPT_CLAIM.search(prompt)) and bool(_NUMBER.search(prompt))
+
+
+@register("math")
+def verify(prompt: str, candidate: str) -> bool | None:
+    if not claims(prompt):
+        return None
+    return extract_answer(candidate) is not None
+
+
+verify.claims = claims  # type: ignore[attr-defined]

--- a/lile/objectives/verifiers/_math.py
+++ b/lile/objectives/verifiers/_math.py
@@ -15,6 +15,12 @@ import re
 from . import register
 
 # Explicit boxed / labelled answer patterns, tried in order.
+#
+# Intentionally narrow: scientific notation (``1.5e10`` → ``1.5``) and
+# fractions (``3/4`` → ``3``) are treated as the integer/decimal prefix.
+# Fine for GSM8K-style benches where the final answer is always a plain
+# decimal; TTRL layers equivalence hashing on top of ``extract_answer``
+# when richer number shapes matter.
 _ANSWER_PATTERNS = (
     re.compile(r"####\s*(-?\d[\d,]*(?:\.\d+)?)"),
     re.compile(r"\\boxed\{\s*(-?\d[\d,]*(?:\.\d+)?)\s*\}"),

--- a/lile/tests/test_verifiers.py
+++ b/lile/tests/test_verifiers.py
@@ -11,6 +11,8 @@ Covers:
 """
 from __future__ import annotations
 
+import threading
+
 import pytest
 
 pytestmark = pytest.mark.cpu_only
@@ -150,3 +152,23 @@ def test_code_verify_false_on_infinite_loop():
     prompt = "Expected: never"
     candidate = "```python\nwhile True: pass\n```"
     assert verify("code", prompt, candidate) is False
+
+
+def test_code_verify_works_from_worker_thread():
+    """Regression: ``signal.signal`` is main-thread-only; off-thread callers
+    used to silently drop to ``None`` because ``verify`` swallowed the
+    ``ValueError``. The guard in ``_run_sandboxed`` skips alarm install off
+    the main thread so the verification itself still runs."""
+    prompt = "Expected: ok"
+    candidate = "```python\nprint('ok')\n```"
+
+    results: list[object] = []
+
+    def _run():
+        results.append(verify("code", prompt, candidate))
+
+    t = threading.Thread(target=_run)
+    t.start()
+    t.join(timeout=5.0)
+    assert not t.is_alive()
+    assert results == [True]

--- a/lile/tests/test_verifiers.py
+++ b/lile/tests/test_verifiers.py
@@ -1,0 +1,152 @@
+"""Seed verifier registry — pins the contract for W2 (unblocks PR L / TTRL).
+
+Covers:
+
+- Registry dispatch (known domain, unknown domain, exception swallowing).
+- ``select(prompt)`` routing between math and code domains.
+- Math verifier: answer extraction, non-math prompt returns None,
+  fallback-last-number path, boxed + ``####`` + ``answer: N`` forms.
+- Code verifier: expected-match pass, missing code block, runtime error,
+  sandbox escape (``__import__`` blocked), wall-clock timeout.
+"""
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.cpu_only
+
+from lile.objectives.verifiers import VERIFIERS, register, select, verify
+from lile.objectives.verifiers._math import extract_answer
+from lile.objectives.verifiers._code import extract_code, extract_expected
+
+
+# ---------------------------------------------------------------- registry
+
+
+def test_registry_seeded_with_math_and_code():
+    assert "math" in VERIFIERS
+    assert "code" in VERIFIERS
+
+
+def test_verify_unknown_domain_returns_none():
+    assert verify("does_not_exist", "p", "c") is None
+
+
+def test_verify_swallows_verifier_exceptions():
+    @register("boom_test")
+    def _boom(prompt: str, candidate: str):
+        raise RuntimeError("verifier blew up")
+
+    try:
+        assert verify("boom_test", "p", "c") is None
+    finally:
+        VERIFIERS.pop("boom_test", None)
+
+
+def test_register_decorator_returns_fn_unchanged():
+    def _fn(p, c):
+        return True
+    try:
+        wrapped = register("noop_test")(_fn)
+        assert wrapped is _fn
+        assert VERIFIERS["noop_test"] is _fn
+    finally:
+        VERIFIERS.pop("noop_test", None)
+
+
+# ---------------------------------------------------------------- select
+
+
+def test_select_math_for_arithmetic_prompt():
+    assert select("How many apples are left if Jane has 3 and gives 1 away?") == "math"
+
+
+def test_select_code_for_expected_output_prompt():
+    prompt = "Write a program that prints hello. Expected: hello"
+    assert select(prompt) == "code"
+
+
+def test_select_none_for_unclaimed_prompt():
+    assert select("tell me a story about dragons") is None
+
+
+# ---------------------------------------------------------------- math
+
+
+@pytest.mark.parametrize("text,expected", [
+    ("The answer is 42.", "42"),
+    ("#### 17", "17"),
+    ("#### -3.50", "-3.5"),
+    ("so we get \\boxed{128}.", "128"),
+    ("Answer: 1,234", "1234"),
+    ("Step 1: 2+2=4. Final: 12", "12"),  # fallback to last number
+    ("no numbers here", None),
+])
+def test_math_extract_answer(text, expected):
+    assert extract_answer(text) == expected
+
+
+def test_math_verify_pass_on_math_prompt():
+    assert verify("math", "How many apples? 3 + 4.", "So 3 + 4 = 7. #### 7") is True
+
+
+def test_math_verify_none_on_non_math_prompt():
+    # Non-math prompt: verifier declines rather than failing.
+    assert verify("math", "tell me a joke", "7") is None
+
+
+def test_math_verify_false_on_no_extractable_answer():
+    assert verify("math", "What is 2 + 2?", "I don't know!") is False
+
+
+# ---------------------------------------------------------------- code
+
+
+def test_code_extract_expected_and_code_roundtrip():
+    prompt = "Print the first 3 squares. Expected: 1 4 9"
+    candidate = "```python\nprint(' '.join(str(i*i) for i in range(1,4)))\n```"
+    assert extract_expected(prompt) == "1 4 9"
+    assert extract_code(candidate) is not None
+
+
+def test_code_verify_pass():
+    prompt = "Print hello world. Expected: hello world"
+    candidate = "```python\nprint('hello world')\n```"
+    assert verify("code", prompt, candidate) is True
+
+
+def test_code_verify_mismatch_is_false():
+    prompt = "Expected: 1"
+    candidate = "```python\nprint(2)\n```"
+    assert verify("code", prompt, candidate) is False
+
+
+def test_code_verify_none_when_prompt_has_no_expected():
+    candidate = "```python\nprint(1)\n```"
+    assert verify("code", "tell me a joke", candidate) is None
+
+
+def test_code_verify_false_on_missing_fence():
+    assert verify("code", "Expected: 1", "I would write print(1)") is False
+
+
+def test_code_verify_false_on_runtime_error():
+    prompt = "Expected: 1"
+    candidate = "```python\nraise ValueError('nope')\n```"
+    assert verify("code", prompt, candidate) is False
+
+
+def test_code_verify_blocks_import():
+    # Sandbox strips ``__import__`` from builtins, so ``import os`` fails
+    # before it can exfiltrate anything — verify returns False, not True.
+    prompt = "Expected: ok"
+    candidate = "```python\nimport os\nprint('ok')\n```"
+    assert verify("code", prompt, candidate) is False
+
+
+def test_code_verify_false_on_infinite_loop():
+    # SIGALRM trips after 1s — loop raises _ExecTimeout inside the sandbox,
+    # adapter catches it, returns False.
+    prompt = "Expected: never"
+    candidate = "```python\nwhile True: pass\n```"
+    assert verify("code", prompt, candidate) is False


### PR DESCRIPTION
## Summary

Seeds `lile/objectives/verifiers/` per the production-implementation roadmap W2 cross-cutting workstream. Unblocks PR L (TTRL pseudo-reward) and any future RL workstream that needs a checkable-output verifier.

- `VERIFIERS: dict[str, Verifier]` + `@register(domain)` decorator
- `verify(domain, prompt, candidate) -> bool | float | None` dispatcher that swallows adapter exceptions (`log.warning` + `None`) so a bad verifier can't take down the train loop
- `select(prompt) -> str | None` routes a prompt to the first registered verifier whose `claims()` sibling matches — gives TTRL trivial dispatch
- Seed **math** verifier — GSM8K-style answer extraction (`####`, `\boxed{…}`, `answer: N`, fallback to the last number in the response); claims math-shaped prompts
- Seed **code** verifier — executable-subset Python sandbox (restricted builtins, SIGALRM wall-clock budget); claims prompts with an `Expected:` stanza; verifies by capturing stdout and exact-matching

## Test plan

- [x] `lile/tests/test_verifiers.py` — 25 tests, all `cpu_only`
  - registry: dispatch, unknown domain, exception swallowing, decorator identity
  - routing: math prompt → math, code prompt → code, story prompt → None
  - math: 7 extraction shapes (boxed, ####, answer:, comma-thousands, last-number fallback, no-number None); pass / None / False verdict paths
  - code: happy path, mismatch → False, no Expected → None, missing fence → False, runtime error → False, blocked import → False, infinite-loop timeout → False
- [x] Full `cpu_only` suite: 134 passed, 0 failed

## Notes

The code-verifier sandbox is **not** a security boundary. It rejects the obvious escape (`__import__` stripped from builtins) but PR L should wrap this in a real sandbox (nsjail / firecracker) before accepting adversarial user-submitted candidates — that's noted in the module docstring and is PR L's problem, not the registry's.

`select` iterates `VERIFIERS` in insertion order, so math (strictest claim) wins over code on ambiguous prompts. Custom verifiers that need richer routing should register their own dispatch on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)