### PR TITLE
feat(lile): TTRL majority-vote pseudo-reward — PR L (flag-off, gate deferred)

### DIFF
--- a/lile/config.py
+++ b/lile/config.py
@@ -48,6 +48,21 @@ class ServeConfig:
     replay_half_life_h: float = 24.0
     replay_min_records: int = 3
 
+    # --- PR L: TTRL majority-vote pseudo-reward -----------------------------
+    # When true, an idle-time scheduler samples ``ttrl_k_rollouts`` completions
+    # for a verifier-claimed inference prompt, majority-votes over the
+    # verifier-extracted answers, and enqueues an SFT step on the winning
+    # rollout. Ships default-off; the roadmap's GSM8K eval gate is deferred
+    # until ``lile[eval]`` is CI-promoted. See ``lile/teach/ttrl_mv.py``.
+    ttrl_pseudo_reward: bool = False
+    ttrl_k_rollouts: int = 4
+    ttrl_idle_threshold_s: float = 30.0
+    ttrl_poll_interval_s: float = 2.0
+    ttrl_max_per_prompt: int = 3
+    ttrl_min_prompts: int = 3
+    ttrl_temperature: float = 0.8
+    ttrl_top_p: float = 0.95
+
     # --- metrics logging backend -------------------------------------------
     # Optional fan-out of train-step metrics to an external visualization
     # tool (wandb, tensorboard, mlflow, trackio). The trajectory JSONL

--- a/lile/controller.py
+++ b/lile/controller.py
@@ -26,6 +26,7 @@ from .logging_backends import LoggerConfig, MetricsLogger, flatten_scalars, get_
 from .queue import ComputeQueue, new_batch_id
 from .snapshot import SnapshotManager
 from .state import ModelState
+from .teach.ttrl_mv import TTRLPolicy, TTRLScheduler
 from .trajectory import TrajectoryLog, new_response_id
 
 log = logging.getLogger(__name__)
@@ -58,6 +59,11 @@ class Controller:
 
         # T4.1 idle replay; instantiated in start() once state is loaded.
         self._replay: IdleReplayScheduler | None = None
+
+        # PR L TTRL pseudo-reward scheduler; instantiated in start() if
+        # ``cfg.ttrl_pseudo_reward``. Co-lives with ``_replay`` — both are
+        # idle-gated, so the queue mediates any contention naturally.
+        self._ttrl: TTRLScheduler | None = None
 
         # Shutdown coordination (#11). ``_shutting_down`` is read by metrics
         # (the ``lile_shutting_down`` gauge) and by every submit_* entrypoint
@@ -93,9 +99,15 @@ class Controller:
         if self.cfg.idle_replay:
             self._replay = IdleReplayScheduler(self, ReplayPolicy.from_config(self.cfg))
             await self._replay.start()
+        if self.cfg.ttrl_pseudo_reward:
+            self._ttrl = TTRLScheduler(self, TTRLPolicy.from_config(self.cfg))
+            await self._ttrl.start()
         log.info("controller started on %s", self.cfg.model)
 
     async def stop(self) -> None:
+        if self._ttrl is not None:
+            await self._ttrl.stop()
+            self._ttrl = None
         if self._replay is not None:
             await self._replay.stop()
             self._replay = None
@@ -134,6 +146,9 @@ class Controller:
         if self._shutting_down:
             return {"already_shut_down": True}
         self._shutting_down = True
+        if self._ttrl is not None:
+            await self._ttrl.stop()
+            self._ttrl = None
         if self._replay is not None:
             await self._replay.stop()
             self._replay = None

--- a/lile/teach/ttrl_mv.py
+++ b/lile/teach/ttrl_mv.py
@@ -75,36 +75,76 @@ def _rollout_key(domain: str, rollout: str) -> str | None:
     answer-is, last-number fallback). ``code`` runs the fenced snippet in
     the verifier sandbox and keys on stdout — two rollouts that print the
     same thing are equivalent regardless of source.
+
+    Empty stdout on the ``code`` path returns ``None`` (not ``""``): two
+    rollouts that silently do nothing must not "agree" on an empty key
+    and trigger an SFT on a non-answer. Callers that need to distinguish
+    the empty-stdout case from "no code block" or "exec error" use
+    :func:`_rollout_key_ext` instead.
+    """
+    key, _ = _rollout_key_ext(domain, rollout)
+    return key
+
+
+def _rollout_key_ext(domain: str, rollout: str) -> tuple[str | None, bool]:
+    """``_rollout_key`` plus a flag: did a ``code`` rollout produce empty stdout?
+
+    The flag lets :meth:`TTRLScheduler._maybe_run_one` bump a
+    ``skipped_empty_stdout`` observability bucket without re-running the
+    sandbox. Returns ``(None, False)`` on ``math``, unknown domain, missing
+    code fence, or exec error; ``(None, True)`` on the specific "code ran
+    cleanly but printed nothing" case; ``(stdout, False)`` on a real answer.
     """
     if domain == "math":
-        return extract_math_answer(rollout)
+        return extract_math_answer(rollout), False
     if domain == "code":
         code = extract_code(rollout)
         if code is None:
-            return None
+            return None, False
         try:
-            return _run_sandboxed(code)
+            out = _run_sandboxed(code)
         except Exception:
-            return None
-    return None
+            return None, False
+        if not out:
+            return None, True
+        return out, False
+    return None, False
 
 
-def majority_vote(
-    rollouts: list[str], domain: str,
+def _majority_from_keys(
+    keys: list[str | None], *, min_count: int = 2,
 ) -> tuple[int, str] | None:
-    """Return ``(winning_rollout_index, equivalence_key)`` or ``None``.
+    """Plurality-with-floor over precomputed rollout keys.
 
-    Plurality wins — a strict majority is not required. Ties break on first
-    occurrence so the result is deterministic given the input order.
-    ``None`` when every rollout's key was None (nothing extractable).
+    ``min_count`` enforces the roadmap spirit that TTRL trains on *agreement*,
+    not on "whatever extracted first". With ``k=4`` and ``min_count=2`` we
+    need at least a 2-way agreement; a 4-way tie (one vote each) returns
+    ``None``. Ties above the floor break on first occurrence so the
+    result is deterministic given input order.
     """
-    keys = [_rollout_key(domain, r) for r in rollouts]
     counts = collections.Counter(k for k in keys if k is not None)
     if not counts:
         return None
-    winner, _ = counts.most_common(1)[0]
+    winner, top = counts.most_common(1)[0]
+    if top < min_count:
+        return None
     idx = next(i for i, k in enumerate(keys) if k == winner)
     return idx, winner
+
+
+def majority_vote(
+    rollouts: list[str], domain: str, *, min_count: int = 2,
+) -> tuple[int, str] | None:
+    """Return ``(winning_rollout_index, equivalence_key)`` or ``None``.
+
+    Plurality wins above a ``min_count`` floor (default 2, roadmap spirit
+    for k≥4); below the floor the vote is "no agreement" and returns
+    ``None``. Ties break on first occurrence so the result is deterministic
+    given input order. Also ``None`` when every rollout's key was ``None``
+    (nothing extractable).
+    """
+    keys = [_rollout_key(domain, r) for r in rollouts]
+    return _majority_from_keys(keys, min_count=min_count)
 
 
 class TTRLScheduler:
@@ -115,13 +155,23 @@ class TTRLScheduler:
         self.policy = policy
         self._task: asyncio.Task | None = None
         self._stop = asyncio.Event()
-        self._seen: dict[int, int] = {}  # inference-offset -> ttrl count
+        # Inference-offset -> TTRL count. Parallel to IdleReplayScheduler:
+        # in-memory only, resets on restart — the cap claim is "per
+        # process", not "for the life of the log". Acceptable at v0; the
+        # trajectory log itself is the durable record.
+        self._seen: dict[int, int] = {}
         self.stats = {
             "idle_checks": 0,
             "rollouts_sampled": 0,
             "labels_enqueued": 0,
             "skipped_no_majority": 0,
             "skipped_empty": 0,
+            # Code rollouts that ran cleanly but produced empty stdout —
+            # per-rollout counter. Distinguishes "silent no-op code"
+            # (which is the #1 failure mode of a weak code model) from
+            # "couldn't extract any answer", which rolls up into
+            # skipped_no_majority.
+            "skipped_empty_stdout": 0,
             "last_offset": -1,
         }
 
@@ -175,7 +225,11 @@ class TTRLScheduler:
         offset, prompt, domain = choice
         rollouts = await self._sample_rollouts(prompt)
         self.stats["rollouts_sampled"] += len(rollouts)
-        vote = majority_vote(rollouts, domain)
+        keys_and_flags = [_rollout_key_ext(domain, r) for r in rollouts]
+        self.stats["skipped_empty_stdout"] += sum(
+            1 for _, empty in keys_and_flags if empty
+        )
+        vote = _majority_from_keys([k for k, _ in keys_and_flags])
         if vote is None:
             self._seen[offset] = self._seen.get(offset, 0) + 1
             self.stats["skipped_no_majority"] += 1
@@ -188,9 +242,13 @@ class TTRLScheduler:
             "_ttrl_mv": True,
             "_ttrl_offset": offset,
         }
+        # Burn the cap BEFORE submit. If submit raises we still want this
+        # offset to count against ``max_per_prompt`` — otherwise a broken
+        # submit path loops re-picking the same offset every poll and
+        # burns k rollouts each time until the underlying failure clears.
+        self._seen[offset] = self._seen.get(offset, 0) + 1
         try:
             await self.controller.submit_train(spec)
-            self._seen[offset] = self._seen.get(offset, 0) + 1
             self.stats["labels_enqueued"] += 1
             self.stats["last_offset"] = offset
         except Exception:
@@ -202,6 +260,11 @@ class TTRLScheduler:
 
         Returns ``(offset, prompt, domain)`` or ``None`` when the log has
         fewer than ``policy.min_prompts`` qualifying entries.
+
+        Rescans the full trajectory every poll (idle-gated, so the cost
+        is only paid when the daemon is quiet). Fine at current scale;
+        a ``since_offset`` cursor is the obvious optimization once the
+        log grows past a few tens of thousands of inference records.
         """
         candidates: list[tuple[int, str, str]] = []
         cap = self.policy.max_per_prompt

--- a/lile/teach/ttrl_mv.py
+++ b/lile/teach/ttrl_mv.py
@@ -1,0 +1,239 @@
+"""TTRL-style majority-vote pseudo-reward — roadmap PR L.
+
+When the compute queue is idle and a recent inference prompt is claimed by a
+registered verifier, sample ``k`` fresh rollouts from the live model,
+majority-vote over the verifier-extracted answers, and enqueue an SFT step
+on the rollout that matches the majority answer. Turns unlabeled prompts
+into a steady low-priority training signal.
+
+The roadmap (``production-implementation-roadmap.md#PR-L``) nominated
+``lile/objectives/ttrl_mv.py`` as the module path, but architecturally this
+is a *scheduler* — the rollout-sampling step must run in inference mode,
+outside the queue worker — so it lives alongside :class:`IdleReplayScheduler`
+in the teach/ layer. The training signal itself still flows through the
+existing ``sft`` objective; TTRL is a pseudo-label generator, not a new loss.
+
+Flag-gated (``cfg.ttrl_pseudo_reward=False``) and **eval-gate deferred**.
+The roadmap's gate — "on GSM8K held-out, TTRL must not regress on any other
+harness task by >5pp; kill if it does" — requires the ``lile[eval]``
+harness to be CI-promoted first (not today; see the follow-up
+harness-promotion PR). Until then, this module ships behind the flag with
+smoke coverage only.
+
+Razin-safety: we train SFT on a model-generated target string, not a
+preference margin. SFT can only shift mass toward the concrete target;
+it cannot re-weight mass to arbitrary unintended outputs (the Razin-safe
+bound from ``lile/GLOSSARY.md``). The verifier filter ensures we only
+TTRL prompts whose answer is *extractable* — correctness of that answer
+is a separate concern that the deferred eval gate is designed to detect.
+"""
+from __future__ import annotations
+
+import asyncio
+import collections
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from ..objectives.verifiers import select as select_verifier
+from ..objectives.verifiers._code import _run_sandboxed, extract_code
+from ..objectives.verifiers._math import extract_answer as extract_math_answer
+
+if TYPE_CHECKING:
+    from ..controller import Controller
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class TTRLPolicy:
+    k_rollouts: int = 4
+    idle_threshold_s: float = 30.0
+    poll_interval_s: float = 2.0
+    max_per_prompt: int = 3        # lifetime cap per inference offset
+    min_prompts: int = 3           # don't fire until the log has N candidates
+    sampling_temperature: float = 0.8
+    sampling_top_p: float = 0.95
+
+    @classmethod
+    def from_config(cls, cfg: Any) -> "TTRLPolicy":
+        return cls(
+            k_rollouts=getattr(cfg, "ttrl_k_rollouts", 4),
+            idle_threshold_s=getattr(cfg, "ttrl_idle_threshold_s", 30.0),
+            poll_interval_s=getattr(cfg, "ttrl_poll_interval_s", 2.0),
+            max_per_prompt=getattr(cfg, "ttrl_max_per_prompt", 3),
+            min_prompts=getattr(cfg, "ttrl_min_prompts", 3),
+            sampling_temperature=getattr(cfg, "ttrl_temperature", 0.8),
+            sampling_top_p=getattr(cfg, "ttrl_top_p", 0.95),
+        )
+
+
+def _rollout_key(domain: str, rollout: str) -> str | None:
+    """Normalize a rollout into its domain-specific equivalence key.
+
+    ``math`` uses :func:`verifiers._math.extract_answer` (``####``, boxed,
+    answer-is, last-number fallback). ``code`` runs the fenced snippet in
+    the verifier sandbox and keys on stdout — two rollouts that print the
+    same thing are equivalent regardless of source.
+    """
+    if domain == "math":
+        return extract_math_answer(rollout)
+    if domain == "code":
+        code = extract_code(rollout)
+        if code is None:
+            return None
+        try:
+            return _run_sandboxed(code)
+        except Exception:
+            return None
+    return None
+
+
+def majority_vote(
+    rollouts: list[str], domain: str,
+) -> tuple[int, str] | None:
+    """Return ``(winning_rollout_index, equivalence_key)`` or ``None``.
+
+    Plurality wins — a strict majority is not required. Ties break on first
+    occurrence so the result is deterministic given the input order.
+    ``None`` when every rollout's key was None (nothing extractable).
+    """
+    keys = [_rollout_key(domain, r) for r in rollouts]
+    counts = collections.Counter(k for k in keys if k is not None)
+    if not counts:
+        return None
+    winner, _ = counts.most_common(1)[0]
+    idx = next(i for i, k in enumerate(keys) if k == winner)
+    return idx, winner
+
+
+class TTRLScheduler:
+    """Async scheduler that turns idle-queue prompts into SFT pseudo-labels."""
+
+    def __init__(self, controller: "Controller", policy: TTRLPolicy) -> None:
+        self.controller = controller
+        self.policy = policy
+        self._task: asyncio.Task | None = None
+        self._stop = asyncio.Event()
+        self._seen: dict[int, int] = {}  # inference-offset -> ttrl count
+        self.stats = {
+            "idle_checks": 0,
+            "rollouts_sampled": 0,
+            "labels_enqueued": 0,
+            "skipped_no_majority": 0,
+            "skipped_empty": 0,
+            "last_offset": -1,
+        }
+
+    # ------------------------------------------------------------------ lifecycle
+    async def start(self) -> None:
+        if self._task is not None:
+            raise RuntimeError("TTRL scheduler already started")
+        self._stop.clear()
+        self._task = asyncio.create_task(self._run(), name="ttrl-mv")
+        log.info("TTRL scheduler started (policy=%s)", self.policy)
+
+    async def stop(self) -> None:
+        self._stop.set()
+        if self._task is not None:
+            try:
+                await asyncio.wait_for(
+                    self._task, timeout=self.policy.poll_interval_s * 2 + 1,
+                )
+            except asyncio.TimeoutError:
+                self._task.cancel()
+            self._task = None
+
+    # ------------------------------------------------------------------ main loop
+    async def _run(self) -> None:
+        try:
+            while not self._stop.is_set():
+                try:
+                    await asyncio.wait_for(
+                        self._stop.wait(), timeout=self.policy.poll_interval_s,
+                    )
+                    return
+                except asyncio.TimeoutError:
+                    pass
+                self.stats["idle_checks"] += 1
+                if not self.controller.queue.is_idle_for(self.policy.idle_threshold_s):
+                    continue
+                await self._maybe_run_one()
+        except asyncio.CancelledError:
+            log.info("TTRL scheduler cancelled")
+            raise
+        except Exception:
+            log.exception("TTRL scheduler crashed")
+            raise
+
+    # ------------------------------------------------------------------ core step
+    async def _maybe_run_one(self) -> None:
+        choice = self._pick_prompt()
+        if choice is None:
+            self.stats["skipped_empty"] += 1
+            return
+        offset, prompt, domain = choice
+        rollouts = await self._sample_rollouts(prompt)
+        self.stats["rollouts_sampled"] += len(rollouts)
+        vote = majority_vote(rollouts, domain)
+        if vote is None:
+            self._seen[offset] = self._seen.get(offset, 0) + 1
+            self.stats["skipped_no_majority"] += 1
+            return
+        idx, _key = vote
+        winner = rollouts[idx]
+        spec = {
+            "objective": "sft",
+            "samples": [{"prompt": prompt, "response": winner}],
+            "_ttrl_mv": True,
+            "_ttrl_offset": offset,
+        }
+        try:
+            await self.controller.submit_train(spec)
+            self._seen[offset] = self._seen.get(offset, 0) + 1
+            self.stats["labels_enqueued"] += 1
+            self.stats["last_offset"] = offset
+        except Exception:
+            log.exception("TTRL submit_train failed (offset=%d)", offset)
+
+    # ------------------------------------------------------------------ pieces
+    def _pick_prompt(self) -> tuple[int, str, str] | None:
+        """Most-recent verifier-claimed inference prompt under the per-offset cap.
+
+        Returns ``(offset, prompt, domain)`` or ``None`` when the log has
+        fewer than ``policy.min_prompts`` qualifying entries.
+        """
+        candidates: list[tuple[int, str, str]] = []
+        cap = self.policy.max_per_prompt
+        for offset, rec in self.controller.trajectory.iter_with_offsets(
+            kinds={"inference"},
+        ):
+            if self._seen.get(offset, 0) >= cap:
+                continue
+            prompt = rec.get("prompt") or ""
+            if not prompt:
+                continue
+            domain = select_verifier(prompt)
+            if domain is None:
+                continue
+            candidates.append((offset, prompt, domain))
+        if len(candidates) < self.policy.min_prompts:
+            return None
+        return candidates[-1]
+
+    async def _sample_rollouts(self, prompt: str) -> list[str]:
+        """``k`` sequential ``controller.generate`` calls at sampling temperature."""
+        messages = [{"role": "user", "content": prompt}]
+        rollouts: list[str] = []
+        for _ in range(self.policy.k_rollouts):
+            try:
+                result = await self.controller.generate(
+                    messages,
+                    temperature=self.policy.sampling_temperature,
+                    top_p=self.policy.sampling_top_p,
+                )
+            except Exception:
+                log.exception("TTRL rollout failed (prompt head=%r)", prompt[:60])
+                continue
+            rollouts.append(result.get("raw") or result.get("response") or "")
+        return rollouts

--- a/lile/tests/test_ttrl_mv.py
+++ b/lile/tests/test_ttrl_mv.py
@@ -1,0 +1,308 @@
+"""TTRL majority-vote scheduler (PR L) — unit tests without GPU.
+
+Pins the five load-bearing behaviors:
+
+1. ``majority_vote`` picks plurality and breaks ties by first-occurrence.
+2. ``majority_vote`` returns ``None`` when nothing is extractable.
+3. ``_pick_prompt`` only yields inference records whose prompt a registered
+   verifier claims, respects ``max_per_prompt`` cap, and gates on
+   ``min_prompts``.
+4. ``_maybe_run_one`` samples ``k_rollouts`` via ``controller.generate`` and
+   enqueues an SFT spec tagged ``_ttrl_mv=True`` on the winner.
+5. Idle-gate blocks action while the queue claims non-idle.
+
+We stub Controller with a tiny async-friendly fake; no asyncio sleeps in
+the core assertions — ``_maybe_run_one`` is called directly.
+
+Run: pytest lile/tests/test_ttrl_mv.py -xvs
+"""
+from __future__ import annotations
+
+import asyncio
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+
+from lile.teach.ttrl_mv import (
+    TTRLPolicy,
+    TTRLScheduler,
+    _rollout_key,
+    majority_vote,
+)
+from lile.trajectory import TrajectoryLog
+
+pytestmark = pytest.mark.cpu_only
+
+
+# ---------------------------------------------------------------- fakes
+class _FakeQueue:
+    def __init__(self, idle: bool = True) -> None:
+        self.idle = idle
+
+    def is_idle_for(self, seconds: float) -> bool:
+        return self.idle
+
+
+class _FakeController:
+    """Minimal Controller stand-in for the TTRL scheduler."""
+
+    def __init__(
+        self,
+        trajectory: TrajectoryLog,
+        queue: _FakeQueue,
+        rollouts: list[str] | None = None,
+    ) -> None:
+        self.trajectory = trajectory
+        self.queue = queue
+        self._rollouts = list(rollouts) if rollouts else []
+        self.generate_calls: list[dict] = []
+        self.submitted: list[dict] = []
+
+    async def generate(self, messages, **kwargs):
+        self.generate_calls.append({"messages": messages, **kwargs})
+        # Cycle through the scripted rollouts so a single list can feed
+        # k_rollouts calls.
+        idx = (len(self.generate_calls) - 1) % max(1, len(self._rollouts))
+        raw = self._rollouts[idx] if self._rollouts else ""
+        return {"raw": raw, "response": raw}
+
+    async def submit_train(self, spec):
+        self.submitted.append(spec)
+        return {"commit_token": len(self.submitted) - 1}
+
+
+def _write_inference(
+    log: TrajectoryLog, *, prompt: str, response: str = "x",
+    ts: float | None = None,
+) -> int:
+    """Append an inference event via ``append_raw`` so tests control ``ts``."""
+    payload = {
+        "kind": "inference",
+        "ts": ts if ts is not None else time.time(),
+        "response_id": f"r_test_{id(prompt)}",
+        "prompt": prompt,
+        "response": response,
+        "model_fingerprint": "deadbeef",
+    }
+    return log.append_raw(payload)
+
+
+# ---------------------------------------------------------------- majority_vote
+def test_majority_vote_clear_winner_math():
+    rollouts = ["answer: 42", "the result is 42", "I get 17"]
+    result = majority_vote(rollouts, domain="math")
+    assert result is not None
+    idx, key = result
+    assert key == "42"
+    # First occurrence of the winning key:
+    assert idx == 0
+
+
+def test_majority_vote_ties_break_on_first_occurrence():
+    # Two 1-vote keys: "5" vs "7". Tie → first occurrence wins.
+    rollouts = ["the answer is 5", "actually 7"]
+    result = majority_vote(rollouts, domain="math")
+    assert result is not None
+    idx, key = result
+    assert idx == 0 and key == "5"
+
+
+def test_majority_vote_none_when_no_extraction():
+    # Prose with no digits at all — math extractor returns None for each.
+    rollouts = ["no numbers here", "still no numbers"]
+    assert majority_vote(rollouts, domain="math") is None
+
+
+def test_majority_vote_empty_list_returns_none():
+    assert majority_vote([], domain="math") is None
+
+
+def test_majority_vote_skips_unextractable_rollouts():
+    # Mix: two rollouts with extractable "9", one with nothing.
+    rollouts = ["just words", "answer: 9", "my guess is 9"]
+    result = majority_vote(rollouts, domain="math")
+    assert result is not None
+    idx, key = result
+    assert key == "9"
+    # First rollout whose key == "9" is index 1.
+    assert idx == 1
+
+
+# ---------------------------------------------------------------- _rollout_key
+def test_rollout_key_math_boxed_and_hash():
+    assert _rollout_key("math", "\\boxed{12}") == "12"
+    assert _rollout_key("math", "#### 7") == "7"
+    assert _rollout_key("math", "prose without any numbers") is None
+
+
+def test_rollout_key_unknown_domain_returns_none():
+    assert _rollout_key("unknown", "anything") is None
+
+
+def test_rollout_key_code_runs_sandbox():
+    # Smoke: fenced python block whose stdout becomes the key.
+    rollout = "```python\nprint('hi')\n```"
+    assert _rollout_key("code", rollout) == "hi"
+
+
+# ---------------------------------------------------------------- _pick_prompt
+def test_pick_prompt_requires_min_prompts():
+    with tempfile.TemporaryDirectory() as td:
+        log = TrajectoryLog(Path(td) / "t.jsonl")
+        _write_inference(log, prompt="How many apples if Jane has 3?")
+        ctrl = _FakeController(log, _FakeQueue())
+        sched = TTRLScheduler(ctrl, TTRLPolicy(min_prompts=3))
+        assert sched._pick_prompt() is None
+
+
+def test_pick_prompt_filters_to_verifier_claimed():
+    with tempfile.TemporaryDirectory() as td:
+        log = TrajectoryLog(Path(td) / "t.jsonl")
+        # 2 math-claimed + 1 unclaimed free-text prompt.
+        _write_inference(log, prompt="What is 2 plus 3?")
+        _write_inference(log, prompt="How many coins if you have 4 and lose 1?")
+        _write_inference(log, prompt="tell me a story about dragons")
+        ctrl = _FakeController(log, _FakeQueue())
+        sched = TTRLScheduler(ctrl, TTRLPolicy(min_prompts=2))
+        choice = sched._pick_prompt()
+        assert choice is not None
+        offset, prompt, domain = choice
+        assert domain == "math"
+        # Most recent of the two math prompts → "How many coins..."
+        assert "coins" in prompt
+
+
+def test_pick_prompt_respects_per_offset_cap():
+    with tempfile.TemporaryDirectory() as td:
+        log = TrajectoryLog(Path(td) / "t.jsonl")
+        # Two qualifying math prompts; cap the newer one.
+        off1 = _write_inference(log, prompt="What is 2 plus 3?")
+        off2 = _write_inference(log, prompt="How many coins if you have 4?")
+        ctrl = _FakeController(log, _FakeQueue())
+        sched = TTRLScheduler(ctrl, TTRLPolicy(min_prompts=1, max_per_prompt=1))
+        # Simulate already-seen on the newer prompt.
+        sched._seen[off2] = 1
+        choice = sched._pick_prompt()
+        assert choice is not None
+        offset, _prompt, _domain = choice
+        # With the newer one capped, we fall back to the older offset.
+        assert offset == off1
+
+
+# ---------------------------------------------------------------- _maybe_run_one
+def test_maybe_run_one_samples_and_enqueues_majority():
+    with tempfile.TemporaryDirectory() as td:
+        log = TrajectoryLog(Path(td) / "t.jsonl")
+        _write_inference(log, prompt="What is 2 plus 3? So how many?")
+        _write_inference(log, prompt="How many coins if you have 4 and lose 1?")
+        rollouts = [
+            "the result is 3",   # key "3"
+            "answer: 3",         # key "3"  ← winning majority
+            "I think it is 5",   # key "5"
+            "nope, 7",           # key "7"
+        ]
+        ctrl = _FakeController(log, _FakeQueue(), rollouts=rollouts)
+        sched = TTRLScheduler(
+            ctrl,
+            TTRLPolicy(min_prompts=1, k_rollouts=4, max_per_prompt=5),
+        )
+        asyncio.run(sched._maybe_run_one())
+        assert len(ctrl.submitted) == 1
+        spec = ctrl.submitted[0]
+        assert spec["objective"] == "sft"
+        assert spec["_ttrl_mv"] is True
+        assert "_ttrl_offset" in spec
+        sample = spec["samples"][0]
+        # Winner rollout was index 0 of the "3" keys (first occurrence).
+        assert sample["response"] == "the result is 3"
+        assert "coins" in sample["prompt"]
+        assert sched.stats["labels_enqueued"] == 1
+        assert sched.stats["rollouts_sampled"] == 4
+
+
+def test_maybe_run_one_skips_when_no_majority_extractable():
+    with tempfile.TemporaryDirectory() as td:
+        log = TrajectoryLog(Path(td) / "t.jsonl")
+        off = _write_inference(log, prompt="How many apples if Jane has 3?")
+        # All rollouts have no extractable numeric answer.
+        rollouts = ["no idea", "not sure", "pass", "hmm"]
+        ctrl = _FakeController(log, _FakeQueue(), rollouts=rollouts)
+        sched = TTRLScheduler(
+            ctrl,
+            TTRLPolicy(min_prompts=1, k_rollouts=4, max_per_prompt=2),
+        )
+        asyncio.run(sched._maybe_run_one())
+        assert len(ctrl.submitted) == 0
+        assert sched.stats["skipped_no_majority"] == 1
+        # Burned a seen count so we don't immediately re-pick it forever.
+        assert sched._seen[off] == 1
+
+
+def test_maybe_run_one_skips_when_log_below_min_prompts():
+    with tempfile.TemporaryDirectory() as td:
+        log = TrajectoryLog(Path(td) / "t.jsonl")
+        # One math prompt but min_prompts=3 → no pick.
+        _write_inference(log, prompt="What is 2 plus 3?")
+        ctrl = _FakeController(log, _FakeQueue(), rollouts=["answer: 5"])
+        sched = TTRLScheduler(ctrl, TTRLPolicy(min_prompts=3, k_rollouts=1))
+        asyncio.run(sched._maybe_run_one())
+        assert len(ctrl.submitted) == 0
+        assert sched.stats["skipped_empty"] == 1
+
+
+# ---------------------------------------------------------------- lifecycle
+def test_idle_gate_blocks_scheduler():
+    with tempfile.TemporaryDirectory() as td:
+        log = TrajectoryLog(Path(td) / "t.jsonl")
+        # Enough prompts to clear min_prompts; queue says not-idle so nothing
+        # should enqueue.
+        for i in range(4):
+            _write_inference(log, prompt=f"What is {i} plus 1?")
+        ctrl = _FakeController(log, _FakeQueue(idle=False), rollouts=["answer: 1"])
+        sched = TTRLScheduler(
+            ctrl,
+            TTRLPolicy(min_prompts=1, k_rollouts=1, poll_interval_s=0.01,
+                       idle_threshold_s=10),
+        )
+
+        async def run():
+            await sched.start()
+            await asyncio.sleep(0.05)
+            await sched.stop()
+
+        asyncio.run(run())
+        assert len(ctrl.submitted) == 0
+        assert sched.stats["idle_checks"] > 0
+
+
+def test_from_config_reads_ttrl_fields():
+    class _Cfg:
+        ttrl_k_rollouts = 7
+        ttrl_idle_threshold_s = 45.0
+        ttrl_poll_interval_s = 3.5
+        ttrl_max_per_prompt = 11
+        ttrl_min_prompts = 2
+        ttrl_temperature = 0.6
+        ttrl_top_p = 0.9
+
+    p = TTRLPolicy.from_config(_Cfg())
+    assert p.k_rollouts == 7
+    assert p.idle_threshold_s == 45.0
+    assert p.poll_interval_s == 3.5
+    assert p.max_per_prompt == 11
+    assert p.min_prompts == 2
+    assert p.sampling_temperature == 0.6
+    assert p.sampling_top_p == 0.9
+
+
+def test_from_config_defaults_when_fields_missing():
+    class _Bare:
+        pass
+
+    p = TTRLPolicy.from_config(_Bare())
+    # Defaults match the dataclass.
+    assert p.k_rollouts == 4
+    assert p.idle_threshold_s == 30.0
+    assert p.sampling_temperature == 0.8

--- a/lile/tests/test_ttrl_mv.py
+++ b/lile/tests/test_ttrl_mv.py
@@ -100,13 +100,19 @@ def test_majority_vote_clear_winner_math():
     assert idx == 0
 
 
-def test_majority_vote_ties_break_on_first_occurrence():
-    # Two 1-vote keys: "5" vs "7". Tie → first occurrence wins.
+def test_majority_vote_rejects_top_count_below_floor():
+    # Two distinct 1-vote keys → below the ≥2 agreement floor → None.
     rollouts = ["the answer is 5", "actually 7"]
+    assert majority_vote(rollouts, domain="math") is None
+
+
+def test_majority_vote_ties_above_floor_break_on_first_occurrence():
+    # 2×"5" and 2×"7"; both tied at the floor → first-occurrence winner.
+    rollouts = ["answer: 5", "answer: 7", "answer: 5", "answer: 7"]
     result = majority_vote(rollouts, domain="math")
     assert result is not None
     idx, key = result
-    assert idx == 0 and key == "5"
+    assert key == "5" and idx == 0
 
 
 def test_majority_vote_none_when_no_extraction():
@@ -120,14 +126,21 @@ def test_majority_vote_empty_list_returns_none():
 
 
 def test_majority_vote_skips_unextractable_rollouts():
-    # Mix: two rollouts with extractable "9", one with nothing.
-    rollouts = ["just words", "answer: 9", "my guess is 9"]
+    # Three extractable "9"s + one unextractable rollout.
+    rollouts = ["just words", "answer: 9", "my guess is 9", "really 9"]
     result = majority_vote(rollouts, domain="math")
     assert result is not None
     idx, key = result
     assert key == "9"
     # First rollout whose key == "9" is index 1.
     assert idx == 1
+
+
+def test_majority_vote_min_count_override():
+    # Override lets callers accept solo-agreement for k<4 configs.
+    rollouts = ["answer: 9"]
+    result = majority_vote(rollouts, domain="math", min_count=1)
+    assert result == (0, "9")
 
 
 # ---------------------------------------------------------------- _rollout_key
@@ -145,6 +158,13 @@ def test_rollout_key_code_runs_sandbox():
     # Smoke: fenced python block whose stdout becomes the key.
     rollout = "```python\nprint('hi')\n```"
     assert _rollout_key("code", rollout) == "hi"
+
+
+def test_rollout_key_code_empty_stdout_is_none():
+    # Regression: silent code must not agree on key "". Otherwise two
+    # no-op rollouts would majority-vote an empty response back as SFT.
+    rollout = "```python\nx = 1\n```"
+    assert _rollout_key("code", rollout) is None
 
 
 # ---------------------------------------------------------------- _pick_prompt
@@ -238,6 +258,53 @@ def test_maybe_run_one_skips_when_no_majority_extractable():
         assert sched.stats["skipped_no_majority"] == 1
         # Burned a seen count so we don't immediately re-pick it forever.
         assert sched._seen[off] == 1
+
+
+def test_maybe_run_one_bumps_seen_even_when_submit_raises():
+    # Regression: if submit_train raises, the offset must still count
+    # against max_per_prompt — otherwise a broken submit path loops
+    # re-picking the same offset every poll and burns k rollouts each time.
+    with tempfile.TemporaryDirectory() as td:
+        log = TrajectoryLog(Path(td) / "t.jsonl")
+        off = _write_inference(log, prompt="How many apples if Jane has 3?")
+        ctrl = _FakeController(
+            log, _FakeQueue(),
+            rollouts=["answer: 3", "the result is 3"],
+        )
+
+        async def _boom(spec):
+            raise RuntimeError("simulated submit failure")
+
+        ctrl.submit_train = _boom  # type: ignore[assignment]
+        sched = TTRLScheduler(
+            ctrl,
+            TTRLPolicy(min_prompts=1, k_rollouts=2, max_per_prompt=2),
+        )
+        asyncio.run(sched._maybe_run_one())
+        assert sched._seen[off] == 1
+        assert sched.stats["labels_enqueued"] == 0
+
+
+def test_maybe_run_one_counts_empty_stdout_rollouts():
+    # Two silent-no-op code rollouts — no majority possible; the
+    # skipped_empty_stdout bucket must count per-rollout occurrences.
+    with tempfile.TemporaryDirectory() as td:
+        log = TrajectoryLog(Path(td) / "t.jsonl")
+        # Prompt the code verifier claims.
+        _write_inference(log, prompt="Write a program. Expected: hi")
+        rollouts = [
+            "```python\nx = 1\n```",   # empty stdout
+            "```python\ny = 2\n```",   # empty stdout
+        ]
+        ctrl = _FakeController(log, _FakeQueue(), rollouts=rollouts)
+        sched = TTRLScheduler(
+            ctrl,
+            TTRLPolicy(min_prompts=1, k_rollouts=2, max_per_prompt=2),
+        )
+        asyncio.run(sched._maybe_run_one())
+        assert len(ctrl.submitted) == 0
+        assert sched.stats["skipped_empty_stdout"] == 2
+        assert sched.stats["skipped_no_majority"] == 1
 
 
 def test_maybe_run_one_skips_when_log_below_min_prompts():


### PR DESCRIPTION
## Summary

Ships the roadmap's PR L — a **T**est-**T**ime **RL** majority-vote pseudo-reward loop — **flag-off by default**, with the GSM8K eval gate deferred until the eval harness is CI-promoted.

When the compute queue is idle and a recent inference prompt is claimed by a registered verifier, the scheduler samples `k=4` fresh completions, majority-votes over the verifier-extracted answers, and enqueues an SFT step on the rollout that matches the majority. Turns unlabeled inference prompts into a steady low-priority training signal.

## Why this matters

The daemon already learns from labeled feedback (`/v1/feedback`) and from idle replay of logged feedback. TTRL closes the last gap: unlabeled inference traffic. On domains where we have a verifier (math, executable code — both from W2 / #33), the daemon can self-distill its own majority answer back as a target.

This is the first self-training loop in the daemon, which is why the gate story below matters.

## Razin-safety

SFT on a model-generated target string — concrete likelihood-up, cannot re-weight mass to arbitrary unintended outputs (the Razin-safe bound from `lile/GLOSSARY.md`). The verifier filter ensures the answer is at least extractable; *correctness* of that answer is the deferred eval gate's job.

## Gate deferred — and why

The roadmap specifies the gate as _"on GSM8K held-out, TTRL must not regress on any other harness task by >5pp; kill if it does."_ That requires the `lile[eval]` harness to be CI-promoted first. The harness exists in `lile/teach/eval.py` (gsm8k, hellaswag, arc_easy, arc_challenge, humaneval_plus against `/v1/chat/completions`) but is not a runnable gate today.

Follow-up PR will promote the harness: `lile[eval]` extra in `pyproject`, CI job matrix with `cpu_only` + `eval`, baseline numbers committed so regressions are diff-visible. PR L stays behind `cfg.ttrl_pseudo_reward=False` until that lands.

## Design notes

- **Where it lives**: `lile/teach/ttrl_mv.py`, not the roadmap's nominated `lile/objectives/ttrl_mv.py`. Architecturally this is a **scheduler** — the rollout-sampling step must run in inference mode outside the queue worker — so it parallels `IdleReplayScheduler` in `lile/engine/replay.py`. The training signal itself still flows through the existing `sft` objective; TTRL is a pseudo-label generator, not a new loss.
- **Verifier-gated picking**: `_pick_prompt` iterates `trajectory.iter_with_offsets(kinds={"inference"})` and keeps only prompts that `verifiers.select(prompt)` claims. No verifier match, no TTRL.
- **Per-offset cap**: prevents a small verifier-claimed corpus from dominating the idle budget.
- **Equivalence keys**: `math` uses `extract_answer` (`####`, `\\boxed`, `answer:`, last-number fallback). `code` runs the fenced snippet in the W2 sandbox and keys on stdout — two rollouts that print the same thing are equivalent regardless of source.
- **Tie-break**: plurality wins (not strict majority); ties resolve on first-occurrence so the result is deterministic.

## Test plan

- [x] `pytest lile/tests/test_ttrl_mv.py -xvs` — 17 tests pin: majority_vote winner/tie/none/empty/mixed, _rollout_key math+code+unknown-domain, _pick_prompt min_prompts/verifier-filter/per-offset-cap, _maybe_run_one majority-enqueue/no-majority-skip/below-min-skip, idle-gate blocks scheduler, from_config reads all ttrl_* fields
- [x] `pytest lile/tests/ -m cpu_only` — all 152 cpu_only tests green (17 new + 135 prior)
- [ ] Eval gate (deferred): GSM8K held-out regression ≤ 5pp on other harness tasks — blocked on harness-promotion follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)