### PR TITLE
feat(lile): mixed_500 generation op — HF prompts + OpenAI-compat teacher

### DIFF
--- a/lile/teach/replay_streams/build_mixed_500.py
+++ b/lile/teach/replay_streams/build_mixed_500.py
@@ -10,27 +10,28 @@ Each kind split 25/25/25/25 across math / code / common-sense / general
 (rounded by largest remainder to preserve per-kind totals).
 
 Dependencies:
-    - datasets (HF): GSM8K, HumanEval+MBPP, HellaSwag, MMLU.
-    - An OpenAI-compatible endpoint for the cold base model (the lile daemon
-      on :8768 with no active adapter — temporarily `snapshot_load` a
-      `cold_base` snapshot, or run a parallel base-model-only server).
-    - A teacher endpoint for labels / critiques / rewrites. Default:
-      claude-opus-4-7 via the Anthropic API.
+    - datasets (HF): GSM8K, MBPP-sanitized, HellaSwag, MMLU. Imported lazily
+      inside `load_source_prompts` so this module stays importable on a
+      torchless / datasets-less CI runner.
+    - openai (Python SDK): imported lazily inside the teacher client. The
+      teacher talks to either Anthropic's OpenAI-compat endpoint
+      (ANTHROPIC_API_KEY) or OpenAI (OPENAI_API_KEY, gpt-4o-mini default).
+    - A cold Qwen3 daemon on a disjoint port for `cold_generate`. This is
+      the remaining runtime dependency; see `cold_generate` docstring.
 
-This script is idempotent: it caches teacher responses by (prompt, response,
-kind) hash in `.cache/teacher/*.json` next to the output file. Re-running
-with the same --seed and --out regenerates the stream deterministically.
+Deterministic on `--seed` (default 42). Shuffling happens once at write.
 """
 from __future__ import annotations
 
 import argparse
 import hashlib
 import json
+import os
 import random
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, Callable, Iterable, Protocol
 
 
 # ------------------------------------------------------------------ composition
@@ -122,13 +123,29 @@ def _cache_key(*parts: str) -> str:
     return h.hexdigest()[:16]
 
 
-# ------------------------------------------------------------------ stubs
-#
-# The calls below are intentionally stubbed — implementing them requires live
-# model endpoints. The run_stream function composes them into a deterministic
-# pipeline so swapping stubs for real calls is a mechanical change.
-#
-# Each stub's docstring describes the exact contract.
+# ------------------------------------------------------------------ prompts
+def _hellaswag_prompt(ctx: str) -> str:
+    """Frame a HellaSwag context as a single-turn user prompt."""
+    ctx = (ctx or "").strip()
+    return (
+        f"Continue the following passage with one plausible next sentence:\n\n"
+        f"{ctx}\n\nNext:"
+    )
+
+
+def _mmlu_prompt(item: dict[str, Any]) -> str:
+    """Frame an MMLU row as a single-turn user prompt."""
+    q = (item.get("question") or "").strip()
+    choices = item.get("choices") or []
+    if choices:
+        labeled = "\n".join(
+            f"{chr(ord('A') + i)}. {c}" for i, c in enumerate(choices)
+        )
+        return (
+            f"{q}\n\n{labeled}\n\n"
+            "Answer with the single letter (A, B, C, or D) and a brief justification."
+        )
+    return q
 
 
 def load_source_prompts(domain: str, n: int, seed: int) -> list[dict[str, Any]]:
@@ -136,70 +153,218 @@ def load_source_prompts(domain: str, n: int, seed: int) -> list[dict[str, Any]]:
 
     Each returned dict has keys: `prompt`, `ground_truth` (domain-specific),
     `source_idx` (absolute index into the HF split).
-    Deterministic on `seed` — random.Random(seed).sample over the source slice.
+
+    Deterministic on `seed` via `random.Random(seed).sample` over the source
+    slice `[SOURCE_OFFSET, SOURCE_OFFSET + n_window)`, where `n_window` is a
+    capped view into the split so the eval slice `[0, 250)` stays disjoint.
     """
-    raise NotImplementedError(
-        "Wire to datasets.load_dataset(...) per SOURCES[domain]; "
-        f"sample from indices [{SOURCE_OFFSET}, {SOURCE_OFFSET}+N) with "
-        "random.Random(seed).sample to keep ordering reproducible."
+    if domain not in SOURCES:
+        raise KeyError(f"unknown domain {domain!r}; known: {sorted(SOURCES)}")
+    spec = SOURCES[domain]
+
+    try:
+        from datasets import load_dataset  # type: ignore[import-untyped]
+    except ImportError as e:  # pragma: no cover - scaffold guard
+        raise ImportError(
+            "load_source_prompts needs the `datasets` package. "
+            "Install with `uv pip install datasets`."
+        ) from e
+
+    ds = load_dataset(
+        spec["hf_dataset"],
+        spec["hf_config"],
+        split=spec["hf_split"],
     )
+    total = len(ds)
+    # Pool candidate indices from the disjoint range; cap at what the split has.
+    pool_end = min(total, SOURCE_OFFSET + max(n * 4, 200))
+    if pool_end <= SOURCE_OFFSET:
+        raise ValueError(
+            f"{domain}: source split has {total} rows, cannot allocate the "
+            f"disjoint range [{SOURCE_OFFSET}, ...) (eval uses [0, 250))"
+        )
+    pool = list(range(SOURCE_OFFSET, pool_end))
+    if len(pool) < n:
+        raise ValueError(
+            f"{domain}: asked for {n} prompts but the disjoint pool only has "
+            f"{len(pool)} rows (split total = {total})"
+        )
+    rng = random.Random(seed)
+    idxs = rng.sample(pool, n)
+
+    pfield = spec["prompt_field"]
+    gfield = spec["ground_truth_field"]
+    out: list[dict[str, Any]] = []
+    for i in idxs:
+        row = ds[i]
+        if domain == "common-sense":
+            prompt = _hellaswag_prompt(row[pfield])
+        elif domain == "general":
+            prompt = _mmlu_prompt(row)
+        else:
+            prompt = (row[pfield] or "").strip()
+        out.append({
+            "prompt": prompt,
+            "ground_truth": row.get(gfield),
+            "source_idx": int(i),
+        })
+    # Assert disjointness — defensive; tests pin this too.
+    for rec in out:
+        assert rec["source_idx"] >= SOURCE_OFFSET, rec
+    return out
 
 
+# ------------------------------------------------------------------ cold model
 def cold_generate(prompt: str, domain: str, endpoint: str, seed: int) -> str:
     """Call the cold base model (no adapter) via OpenAI-compat endpoint.
 
+    This stub is intentionally not implemented until a cold Qwen3-9B snapshot
+    and a dedicated cold daemon are available. Recipe to fill it in:
+
+    1. Produce a cold snapshot (no active adapter). Either start the trainer
+       daemon with a clean base, POST an empty `/v1/snapshots/save`, or
+       `snapshot_load` a committed `cold_base` snapshot at runtime. The goal
+       is to pin weights == base model + zero delta.
+    2. Spin a *second* daemon instance on a port disjoint from the training
+       daemon (e.g. cold on :8768, trainer on :8766). If VRAM fits, same GPU
+       is fine; otherwise point at a second device via CUDA_VISIBLE_DEVICES.
+    3. POST `{endpoint}/chat/completions` with
+       `{'model': 'current', 'messages': [{'role': 'user', 'content': prompt}]}`
+       — the lile server ignores the model name and uses the live weights.
+       Pass `seed`, `temperature`, `top_p`, and `max_tokens` per domain.
+    4. Wire this function to call that endpoint (use `httpx` or `openai`).
+
     Generation params per-domain (from README):
         math:         max_tokens=512, temperature=0.7, top_p=0.95
-        code:         max_tokens=768
-        common-sense: max_tokens=128
-        general:      max_tokens=256
+        code:         max_tokens=768, temperature=0.7, top_p=0.95
+        common-sense: max_tokens=128, temperature=0.7, top_p=0.95
+        general:      max_tokens=256, temperature=0.7, top_p=0.95
     """
     raise NotImplementedError(
-        "POST to {endpoint}/chat/completions with {'model': 'cold', "
-        "'messages': [{'role': 'user', 'content': prompt}], ...}. "
-        "Use a snapshot_load of `cold_base` to ensure no adapter is active."
+        "cold_generate requires a cold Qwen3 daemon on a disjoint port. "
+        "See the docstring for the cold-daemon recipe."
     )
 
 
-def teacher_label_binary(prompt: str, response: str, domain: str,
-                         ground_truth: Any, teacher_model: str) -> str:
-    """Return "up" or "down" for binary feedback.
+# ------------------------------------------------------------------ teacher client
+class TeacherClient(Protocol):
+    """Protocol for the teacher — any object with these 4 methods plugs in."""
 
-    For math: exact-match on final numeric answer extracted from `response`.
-    For code: execute against `ground_truth["test_list"]` in sandboxed subprocess.
-    For common-sense / general: teacher rubric check (non-refusal + factual).
+    def label_binary(self, *, prompt: str, response: str, domain: str,
+                     ground_truth: Any) -> str: ...
+
+    def rewrite(self, *, prompt: str, response: str, domain: str) -> str: ...
+
+    def critique(self, *, prompt: str, response: str, domain: str) -> str: ...
+
+    def preferred_pair(self, *, prompt: str, response_a: str, response_b: str,
+                       domain: str) -> tuple[str, str]: ...
+
+
+_BINARY_SYSTEM = (
+    "You grade a single model response as 'up' (helpful and correct) or "
+    "'down' (incorrect, unsafe, or unhelpful). Reply with exactly 'up' or 'down'."
+)
+_REWRITE_SYSTEM = (
+    "Rewrite the response so it is correct, helpful, and preserves the "
+    "original format. Reply with only the rewritten response — no preface."
+)
+_CRITIQUE_SYSTEM = (
+    "Write a 1-3 sentence specific, non-vacuous critique of the response "
+    "explaining what is wrong or could be improved. Reply with only the critique."
+)
+_PREF_SYSTEM = (
+    "Compare two candidate responses to the prompt and pick the better one. "
+    "Reply with exactly 'A' or 'B'."
+)
+
+
+@dataclass
+class OpenAICompatTeacher:
+    """Default teacher client: OpenAI-compat SDK with pluggable base_url."""
+
+    model: str
+    api_key: str
+    base_url: str | None = None
+    temperature: float = 0.0
+    max_tokens: int = 512
+
+    def _chat(self, system: str, user: str) -> str:
+        try:
+            from openai import OpenAI  # type: ignore[import-not-found]
+        except ImportError as e:  # pragma: no cover - scaffold guard
+            raise ImportError(
+                "OpenAICompatTeacher needs the `openai` package. "
+                "Install with `uv pip install openai`."
+            ) from e
+        client = OpenAI(api_key=self.api_key, base_url=self.base_url)
+        resp = client.chat.completions.create(
+            model=self.model,
+            messages=[
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
+            temperature=self.temperature,
+            max_tokens=self.max_tokens,
+        )
+        return (resp.choices[0].message.content or "").strip()
+
+    def label_binary(self, *, prompt: str, response: str, domain: str,
+                     ground_truth: Any) -> str:
+        gt = "" if ground_truth is None else f"\n\nReference: {ground_truth!s}"
+        user = f"Prompt:\n{prompt}\n\nResponse:\n{response}{gt}"
+        out = self._chat(_BINARY_SYSTEM, user).lower()
+        return "up" if "up" in out and "down" not in out else "down"
+
+    def rewrite(self, *, prompt: str, response: str, domain: str) -> str:
+        user = (
+            f"Prompt:\n{prompt}\n\n"
+            f"Original response:\n{response}\n\nRewritten response:"
+        )
+        return self._chat(_REWRITE_SYSTEM, user)
+
+    def critique(self, *, prompt: str, response: str, domain: str) -> str:
+        user = f"Prompt:\n{prompt}\n\nResponse:\n{response}\n\nCritique:"
+        return self._chat(_CRITIQUE_SYSTEM, user)
+
+    def preferred_pair(self, *, prompt: str, response_a: str,
+                       response_b: str, domain: str) -> tuple[str, str]:
+        user = (
+            f"Prompt:\n{prompt}\n\nResponse A:\n{response_a}\n\n"
+            f"Response B:\n{response_b}\n\nWhich is better? Reply A or B."
+        )
+        pick = self._chat(_PREF_SYSTEM, user).strip().upper()
+        # Tie / malformed → keep declared order so the run is deterministic.
+        if pick.startswith("B"):
+            return response_b, response_a
+        return response_a, response_b
+
+
+def default_teacher(model: str) -> TeacherClient:
+    """Construct a teacher client from env.
+
+    Lookup order:
+    1. ANTHROPIC_API_KEY → Anthropic's OpenAI-compat endpoint with `model`.
+    2. OPENAI_API_KEY    → OpenAI; if `model` looks Anthropic (claude-*),
+                           fall back to `gpt-4o-mini`.
+
+    Raises `RuntimeError` with a clear message if neither is set.
     """
-    raise NotImplementedError(
-        "Ground-truth check for math/code; teacher API for fuzzy domains."
-    )
-
-
-def teacher_rewrite(prompt: str, response: str, domain: str,
-                    teacher_model: str) -> str:
-    """Teacher-generated better response for `rewrite` records."""
-    raise NotImplementedError(
-        "Anthropic API call: 'Rewrite to be correct/helpful, preserve format.'"
-    )
-
-
-def teacher_critique(prompt: str, response: str, domain: str,
-                     teacher_model: str) -> str:
-    """Teacher-generated 1-3 sentence critique for `nl_critique` records."""
-    raise NotImplementedError(
-        "Anthropic API call: 'Write a 1-3 sentence specific critique.'"
-    )
-
-
-def teacher_preferred_pair(prompt: str, domain: str, endpoint: str,
-                           teacher_model: str, seed: int) -> tuple[str, str]:
-    """Return (chosen, rejected) for `preferred` records.
-
-    Samples two responses at temperature=0.7; chosen is the one that passes
-    ground-truth or teacher rubric. If both pass or both fail, re-sample.
-    """
-    raise NotImplementedError(
-        "Two cold_generate calls with different generation seeds; "
-        "teacher_label_binary picks the winner; loop until tiebreak resolves."
+    anthropic_key = os.environ.get("ANTHROPIC_API_KEY")
+    if anthropic_key:
+        return OpenAICompatTeacher(
+            model=model,
+            api_key=anthropic_key,
+            base_url="https://api.anthropic.com/v1/",
+        )
+    openai_key = os.environ.get("OPENAI_API_KEY")
+    if openai_key:
+        fallback = "gpt-4o-mini" if model.startswith("claude") else model
+        return OpenAICompatTeacher(model=fallback, api_key=openai_key)
+    raise RuntimeError(
+        "No teacher API key in env. Set ANTHROPIC_API_KEY "
+        "(preferred, matches README) or OPENAI_API_KEY (falls back to "
+        "gpt-4o-mini when --teacher-model is a Claude model)."
     )
 
 
@@ -208,23 +373,46 @@ def _record_id(idx: int) -> str:
     return f"mixed_500-{idx:04d}"
 
 
-def build_records(endpoint: str, teacher_model: str,
-                  seed: int) -> list[dict[str, Any]]:
-    """Compose the full stream in declared order. Shuffling happens at write."""
+PromptLoader = Callable[[str, int, int], list[dict[str, Any]]]
+ColdGen = Callable[[str, str, str, int], str]
+
+
+def build_records(
+    endpoint: str,
+    teacher_model: str,
+    seed: int,
+    composition: Composition = COMPOSITION,
+    *,
+    teacher: TeacherClient | None = None,
+    prompts_fn: PromptLoader | None = None,
+    cold_fn: ColdGen | None = None,
+) -> list[dict[str, Any]]:
+    """Compose the full stream in declared order. Shuffling happens at write.
+
+    Injection points (all optional — defaults construct the production impls):
+      * `teacher`      — custom `TeacherClient` (tests pass a mock).
+      * `prompts_fn`   — custom prompt loader (tests pass a fixture slice).
+      * `cold_fn`      — custom cold-model callable (tests pass a stub).
+    """
+    teacher = teacher if teacher is not None else default_teacher(teacher_model)
+    prompts_fn = prompts_fn if prompts_fn is not None else load_source_prompts
+    cold_fn = cold_fn if cold_fn is not None else cold_generate
+
     rng = random.Random(seed)
-    split = COMPOSITION.per_kind_by_domain()
+    split = composition.per_kind_by_domain()
     records: list[dict[str, Any]] = []
     idx = 0
 
-    for kind, _total in COMPOSITION.by_kind:
-        for domain in COMPOSITION.domains:
+    for kind, _total in composition.by_kind:
+        for domain in composition.domains:
             n = split[kind][domain]
-            prompts = load_source_prompts(domain, n, seed=seed + hash(kind) % 10_000)
+            if n == 0:
+                continue
+            prompts = prompts_fn(domain, n, seed + hash(kind) % 10_000)
             for item in prompts:
                 idx += 1
                 prompt = item["prompt"]
-                response = cold_generate(prompt, domain, endpoint,
-                                         seed=seed + idx)
+                response = cold_fn(prompt, domain, endpoint, seed + idx)
                 base: dict[str, Any] = {
                     "response_id": _record_id(idx),
                     "feedback_kind": kind,
@@ -234,31 +422,32 @@ def build_records(endpoint: str, teacher_model: str,
                     "source_idx": item["source_idx"],
                 }
                 if kind == "binary":
-                    base["value"] = teacher_label_binary(
-                        prompt, response, domain,
-                        item["ground_truth"], teacher_model,
+                    base["value"] = teacher.label_binary(
+                        prompt=prompt, response=response, domain=domain,
+                        ground_truth=item.get("ground_truth"),
                     )
                 elif kind == "rewrite":
-                    base["better_response"] = teacher_rewrite(
-                        prompt, response, domain, teacher_model,
+                    base["better_response"] = teacher.rewrite(
+                        prompt=prompt, response=response, domain=domain,
                     )
                     base["weight"] = 3.0
                 elif kind == "preferred":
-                    chosen, rejected = teacher_preferred_pair(
-                        prompt, domain, endpoint, teacher_model,
-                        seed=seed + idx,
+                    alt = cold_fn(prompt, domain, endpoint, seed + idx + 10_000)
+                    chosen, rejected = teacher.preferred_pair(
+                        prompt=prompt, response_a=response, response_b=alt,
+                        domain=domain,
                     )
                     base["chosen"] = chosen
                     base["rejected"] = rejected
                 elif kind == "nl_critique":
-                    base["critique"] = teacher_critique(
-                        prompt, response, domain, teacher_model,
+                    base["critique"] = teacher.critique(
+                        prompt=prompt, response=response, domain=domain,
                     )
                     # 20% upgrade to nl_critique_with_rewrite per README.
                     if rng.random() < 0.20:
                         base["feedback_kind"] = "nl_critique_with_rewrite"
-                        base["better_response"] = teacher_rewrite(
-                            prompt, response, domain, teacher_model,
+                        base["better_response"] = teacher.rewrite(
+                            prompt=prompt, response=response, domain=domain,
                         )
                 else:
                     raise AssertionError(f"unknown kind {kind!r}")
@@ -269,7 +458,9 @@ def build_records(endpoint: str, teacher_model: str,
 
 
 def main() -> int:
-    p = argparse.ArgumentParser(prog="python -m lile.teach.replay_streams.build_mixed_500")
+    p = argparse.ArgumentParser(
+        prog="python -m lile.teach.replay_streams.build_mixed_500",
+    )
     p.add_argument("--endpoint", default="http://127.0.0.1:8768/v1",
                    help="OpenAI-compat endpoint of the cold base model")
     p.add_argument("--teacher-model", default="claude-opus-4-7",

--- a/lile/tests/conftest.py
+++ b/lile/tests/conftest.py
@@ -30,6 +30,7 @@ _TORCHLESS_OK = {
     "test_queue_cursor.py",    # lile.queue is pure Python
     "test_reasoning.py",       # lile.reasoning is pure Python
     "test_trajectory_tail.py", # lile.trajectory is pure Python
+    "test_replay_streams.py",  # replay_streams scaffold — stdlib-only imports
     "conftest.py",
     "__init__.py",
 }

--- a/lile/tests/test_replay_streams.py
+++ b/lile/tests/test_replay_streams.py
@@ -16,7 +16,13 @@ from pathlib import Path
 
 import pytest
 
-from lile.teach.replay_streams.build_mixed_500 import COMPOSITION
+from lile.teach.replay_streams.build_mixed_500 import (
+    COMPOSITION,
+    Composition,
+    SOURCE_OFFSET,
+    build_records,
+    default_teacher,
+)
 from lile.teach.replay_streams.validate import validate
 
 pytestmark = pytest.mark.cpu_only
@@ -113,6 +119,159 @@ def test_nl_critique_with_rewrite_is_valid(tmp_path: Path):
     assert validate(p) == 0
 
 
+# -------------------------------------------------------------------- pipeline
+# Exercise `build_records` end-to-end with injected mocks — no HF downloads,
+# no cold daemon, no teacher API. Pins the wire shape for every kind.
+
+
+_MINI = Composition(
+    total=20,
+    by_kind=(
+        ("binary", 8),
+        ("nl_critique", 6),
+        ("rewrite", 4),
+        ("preferred", 2),
+    ),
+    domains=("math", "code", "common-sense", "general"),
+)
+
+
+class _FakeTeacher:
+    """In-process teacher stub — deterministic outputs per kind."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def label_binary(self, *, prompt: str, response: str, domain: str,
+                     ground_truth) -> str:  # noqa: ANN001
+        self.calls.append(f"binary:{domain}")
+        return "up" if len(prompt) % 2 == 0 else "down"
+
+    def rewrite(self, *, prompt: str, response: str, domain: str) -> str:
+        self.calls.append(f"rewrite:{domain}")
+        return f"rewritten[{domain}]: {response}"
+
+    def critique(self, *, prompt: str, response: str, domain: str) -> str:
+        self.calls.append(f"critique:{domain}")
+        return f"critique[{domain}]: {response[:40]}"
+
+    def preferred_pair(self, *, prompt: str, response_a: str, response_b: str,
+                       domain: str) -> tuple[str, str]:
+        self.calls.append(f"pref:{domain}")
+        return response_a, response_b
+
+
+def _fake_prompts(domain: str, n: int, seed: int) -> list[dict]:
+    return [
+        {
+            "prompt": f"[{domain}] question {i}",
+            "ground_truth": f"gt-{domain}-{i}",
+            "source_idx": SOURCE_OFFSET + i,
+        }
+        for i in range(n)
+    ]
+
+
+def _fake_cold(prompt: str, domain: str, endpoint: str, seed: int) -> str:
+    return f"[{domain}] cold reply (seed={seed})"
+
+
+def test_build_records_pipeline_with_mocks(tmp_path: Path):
+    """End-to-end pipeline on a 20-event fixture slice, no network."""
+    teacher = _FakeTeacher()
+    records = build_records(
+        endpoint="http://127.0.0.1:0/v1",
+        teacher_model="mock",
+        seed=42,
+        composition=_MINI,
+        teacher=teacher,
+        prompts_fn=_fake_prompts,
+        cold_fn=_fake_cold,
+    )
+    assert len(records) == _MINI.total
+
+    # Every record has the shape the validator needs.
+    p = tmp_path / "mini.jsonl"
+    p.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+    # Validator is hard-coded for total=500; just assert required fields
+    # directly so this test doesn't depend on a configurable validator.
+    for r in records:
+        assert r["response_id"].startswith("mixed_500-")
+        assert r["source_idx"] >= SOURCE_OFFSET
+        kind = r["feedback_kind"]
+        assert kind in {"binary", "rewrite", "preferred",
+                        "nl_critique", "nl_critique_with_rewrite"}
+        if kind == "binary":
+            assert r["value"] in {"up", "down"}
+        elif kind == "rewrite":
+            assert isinstance(r["better_response"], str)
+            assert r["weight"] == 3.0
+        elif kind == "preferred":
+            assert r["chosen"] and r["rejected"]
+        elif kind == "nl_critique":
+            assert r["critique"]
+        elif kind == "nl_critique_with_rewrite":
+            assert r["critique"] and r["better_response"]
+
+    # Teacher was called for every non-cold path.
+    kinds_seen = {c.split(":", 1)[0] for c in teacher.calls}
+    assert kinds_seen == {"binary", "rewrite", "critique", "pref"}
+
+
+def test_build_records_is_deterministic_on_seed():
+    """Same seed → same record sequence (ordering + content)."""
+    def run():
+        return build_records(
+            endpoint="x", teacher_model="mock", seed=123,
+            composition=_MINI, teacher=_FakeTeacher(),
+            prompts_fn=_fake_prompts, cold_fn=_fake_cold,
+        )
+    a, b = run(), run()
+    assert [r["response_id"] for r in a] == [r["response_id"] for r in b]
+    assert [r["feedback_kind"] for r in a] == [r["feedback_kind"] for r in b]
+    assert [r["prompt"] for r in a] == [r["prompt"] for r in b]
+
+
+def test_default_teacher_errors_clearly_without_keys(monkeypatch):
+    """No API key → a RuntimeError that names both env vars."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    with pytest.raises(RuntimeError) as exc:
+        default_teacher("claude-opus-4-7")
+    msg = str(exc.value)
+    assert "ANTHROPIC_API_KEY" in msg
+    assert "OPENAI_API_KEY" in msg
+
+
+def test_default_teacher_prefers_anthropic(monkeypatch):
+    """ANTHROPIC_API_KEY wins over OPENAI_API_KEY and keeps the caller's model."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-test")
+    t = default_teacher("claude-opus-4-7")
+    assert t.api_key == "sk-ant-test"  # type: ignore[attr-defined]
+    assert t.model == "claude-opus-4-7"  # type: ignore[attr-defined]
+    assert t.base_url == "https://api.anthropic.com/v1/"  # type: ignore[attr-defined]
+
+
+def test_default_teacher_openai_fallback_swaps_claude_model(monkeypatch):
+    """OPENAI_API_KEY only + claude-* model → gpt-4o-mini fallback, no base_url."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-test")
+    t = default_teacher("claude-opus-4-7")
+    assert t.model == "gpt-4o-mini"  # type: ignore[attr-defined]
+    assert t.base_url is None  # type: ignore[attr-defined]
+
+
+def test_cold_generate_is_explicitly_unimplemented():
+    """Scaffold contract: cold_generate must raise NotImplementedError with
+    a message pointing at the cold-daemon recipe so a future implementer
+    knows where to look."""
+    from lile.teach.replay_streams.build_mixed_500 import cold_generate
+    with pytest.raises(NotImplementedError) as exc:
+        cold_generate("hi", "math", "http://localhost:0/v1", 0)
+    assert "cold-daemon recipe" in str(exc.value).lower()
+
+
 def main() -> int:
     test_composition_totals()
     print("[replay-streams] composition totals OK")
@@ -129,6 +288,8 @@ def main() -> int:
         print("[replay-streams] validator rejects bad kind")
         test_nl_critique_with_rewrite_is_valid(tmp_path)
         print("[replay-streams] nl_critique_with_rewrite is valid")
+        test_build_records_pipeline_with_mocks(tmp_path)
+        print("[replay-streams] build_records pipeline with mocks OK")
     return 0
 
 


### PR DESCRIPTION
## Summary

- Real `load_source_prompts` against HF `datasets` for all four domains (GSM8K, MBPP-sanitized, HellaSwag, MMLU), drawing from the disjoint `[SOURCE_OFFSET, SOURCE_OFFSET + 4N)` pool. Deferred import so the module stays torchless-importable.
- 4 teacher methods on a pluggable `OpenAICompatTeacher` (via `openai` SDK, lazy import). `default_teacher(model)` reads `ANTHROPIC_API_KEY` first (Anthropic's OpenAI-compat endpoint, caller's model kept), falls back to `OPENAI_API_KEY` with `gpt-4o-mini` when the requested model is a Claude.
- `cold_generate` stays `NotImplementedError` — docstring is now the cold-daemon recipe (cold snapshot + disjoint port + per-domain `max_tokens`). That's the one remaining blocker; needs a cold Qwen3-9B snapshot we don't have yet.
- Fixes a PR #36 whitelist miss: `test_replay_streams.py` wasn't in `_TORCHLESS_OK`, so it silently wasn't collecting in the `cpu_only` CI bucket. Confirmed via `gh run view` on PR #36's log.

## Path chosen (lead-agreed)

Went with path (a) per product-owner guidance:

> (b) has worse infra friction than your probe showed — ANTHROPIC_API_KEY unset here too, only OPENAI_API_KEY is set; baseline-20260417 snapshot is from the old 0.6B daemon (noted in my memory) so we have NO cold 9B snapshot; and GPU contention with the :8766 trained daemon rules out a second 9B instance on :8768 tonight.

So this PR lands the offline-testable pieces. When a cold Qwen3-9B snapshot exists, filling `cold_generate` is a one-function follow-up.

## Injection points

`build_records` now takes three keyword-only overrides + a `composition`:

```python
build_records(
    endpoint, teacher_model, seed,
    composition=_MINI,          # 20 events for tests
    teacher=FakeTeacher(),      # TeacherClient protocol
    prompts_fn=_fake_prompts,   # (domain, n, seed) -> list[dict]
    cold_fn=_fake_cold,         # (prompt, domain, endpoint, seed) -> str
)
```

Defaults construct the production impls. This keeps the CLI surface unchanged while letting a cpu_only test exercise the full composition-in/shuffle-out pipeline with no network.

## Test plan

- [x] `uv run python -m lile.tests.test_replay_streams` — 12 tests, all pass
- [x] `python -m pytest lile/tests -m cpu_only` — 193 passed, 0 failed
- [x] `python -m pytest lile/tests -m eval` — 8 passed, 0 failed
- [x] `python -m lile.teach.replay_streams.build_mixed_500 --dry-run` — composition splits print cleanly
- [x] Torchless conftest simulation confirms `test_replay_streams.py` is now collected
- [ ] CI (runs on push)

## Out of scope

- Actual `mixed_500.jsonl` generation run — blocked on cold Qwen3-9B snapshot + teacher API key.
- Ground-truth shortcut paths for math/code `label_binary` (`_math.extract_answer` + sandboxed exec). Teacher-only path is fine for scaffolding; ground-truth can be a follow-up once W2's verifier module stabilizes around an API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)