### PR TITLE
feat(lile): verifier tolerance patch — fraction canon + rtol=1e-3

### DIFF
--- a/lile/objectives/verifiers/_math.py
+++ b/lile/objectives/verifiers/_math.py
@@ -6,28 +6,46 @@ response exposes a final, extractable numeric answer.
 
 Equivalence semantics are deliberately minimal here — the verifier only
 reports *extractability*. TTRL layers equivalence hashing on top by
-calling :func:`extract_answer` directly.
+calling :func:`extract_answer` directly. Callers that have a reference
+answer and want tolerant equivalence should use :func:`answers_match`,
+which handles fraction canonicalization and a configurable ``rtol``.
 """
 from __future__ import annotations
 
+import math
 import re
 
 from . import register
 
 # Explicit boxed / labelled answer patterns, tried in order.
 #
-# Intentionally narrow: scientific notation (``1.5e10`` → ``1.5``) and
-# fractions (``3/4`` → ``3``) are treated as the integer/decimal prefix.
-# Fine for GSM8K-style benches where the final answer is always a plain
-# decimal; TTRL layers equivalence hashing on top of ``extract_answer``
-# when richer number shapes matter.
+# Scientific notation (``1.5e10`` → ``1.5``) is treated as the decimal
+# prefix. Fractions (``3/4``) have their own preferred patterns — see
+# :func:`extract_answer` — applied *first* when the prompt signals a
+# fraction answer ("what fraction", "in lowest terms", etc.). Otherwise
+# we fall back to the decimal-only patterns below, keeping the classic
+# GSM8K short-answer shape.
 _ANSWER_PATTERNS = (
     re.compile(r"####\s*(-?\d[\d,]*(?:\.\d+)?)"),
     re.compile(r"\\boxed\{\s*(-?\d[\d,]*(?:\.\d+)?)\s*\}"),
     re.compile(r"(?i)\banswer(?:\s+is)?\s*[:=]?\s*(-?\d[\d,]*(?:\.\d+)?)"),
 )
+
+# Fraction variants of the same anchors. Preferred over the decimal
+# patterns only when the prompt asks for a fraction, to keep the default
+# GSM8K-exact-match path untouched.
+_FRACTION_ANCHORED = (
+    re.compile(r"####\s*(-?\d+\s*/\s*\d+)"),
+    re.compile(r"\\boxed\{\s*(-?\d+\s*/\s*\d+)\s*\}"),
+    re.compile(r"(?i)\banswer(?:\s+is)?\s*[:=]?\s*(-?\d+\s*/\s*\d+)"),
+)
+
 # Fallback: last number anywhere in the response.
 _NUMBER = re.compile(r"-?\d[\d,]*(?:\.\d+)?")
+
+# Fallback for fraction mode: last ``a/b`` anywhere in the response.
+# Anchored on word-like boundaries so we don't eat dates ("3/4/2020").
+_FRACTION = re.compile(r"(?<![\d/])-?\d+\s*/\s*\d+(?![\d/])")
 
 # Cheap prompt classifier — question verb + a digit or arithmetic noun.
 _PROMPT_CLAIM = re.compile(
@@ -35,23 +53,75 @@ _PROMPT_CLAIM = re.compile(
     r"sum of|product of|average|mean|total|percentage|fraction)",
 )
 
+# Prompt phrasing that signals the expected answer is a fraction. Narrow
+# on purpose: "fraction" appearing incidentally ("what is the decimal
+# equivalent of the fraction 3/4") shouldn't flip the mode. Must be an
+# explicit answer-shape directive.
+_FRACTION_PROMPT = re.compile(
+    r"(?i)\b("
+    r"what\s+fraction|"
+    r"as\s+(?:a|the)\s+fraction|"
+    r"express\s+(?:the\s+answer\s+)?as\s+a\s+fraction|"
+    r"(?:give|write|leave)\s+(?:your\s+answer|the\s+answer)\s+as\s+a\s+fraction|"
+    r"in\s+(?:lowest|simplest)\s+(?:terms|form)"
+    r")\b"
+)
 
-def _normalize(s: str) -> str:
+
+def _normalize_decimal(s: str) -> str:
     s = s.replace(",", "")
     if "." in s:
         s = s.rstrip("0").rstrip(".")
     return s or "0"
 
 
-def extract_answer(text: str) -> str | None:
-    """Return the normalized final numeric answer in ``text`` or ``None``."""
+def _normalize_fraction(s: str) -> str:
+    """Strip whitespace in ``a / b`` → ``a/b``. Does not reduce the fraction."""
+    return s.replace(" ", "")
+
+
+def _is_fraction_prompt(prompt: str | None) -> bool:
+    return bool(prompt) and bool(_FRACTION_PROMPT.search(prompt))
+
+
+def extract_answer(text: str, prompt: str | None = None) -> str | None:
+    """Return the normalized final answer in ``text`` or ``None``.
+
+    When ``prompt`` asks for a fraction ("what fraction ...", "as a
+    fraction", "in lowest terms"), fraction patterns (``a/b``) are tried
+    first so responses like "#### 5/8" return ``"5/8"`` rather than
+    being split by the decimal regex into the numerator ``"5"`` alone.
+
+    Without a ``prompt`` hint the behavior is unchanged: the classic
+    ``####``, ``\\boxed{...}``, and "answer: N" patterns are tried in
+    order, then the last number in the text as a fallback. This keeps
+    GSM8K-style short-answer bench behaviour byte-stable.
+    """
+    if _is_fraction_prompt(prompt):
+        for pat in _FRACTION_ANCHORED:
+            m = pat.search(text)
+            if m:
+                return _normalize_fraction(m.group(1))
+        fracs = _FRACTION.findall(text)
+        if fracs:
+            return _normalize_fraction(fracs[-1])
+        # Fraction mode, no fraction in candidate. Fall through to the
+        # anchored decimal patterns only (the model may have answered with
+        # an integer like ``#### 1``). The last-number fallback is *not*
+        # used here — in fraction mode an unanchored year or incidental
+        # number is almost always spurious.
+        for pat in _ANSWER_PATTERNS:
+            m = pat.search(text)
+            if m:
+                return _normalize_decimal(m.group(1))
+        return None
     for pat in _ANSWER_PATTERNS:
         m = pat.search(text)
         if m:
-            return _normalize(m.group(1))
+            return _normalize_decimal(m.group(1))
     matches = _NUMBER.findall(text)
     if matches:
-        return _normalize(matches[-1])
+        return _normalize_decimal(matches[-1])
     return None
 
 
@@ -64,7 +134,79 @@ def claims(prompt: str) -> bool:
 def verify(prompt: str, candidate: str) -> bool | None:
     if not claims(prompt):
         return None
-    return extract_answer(candidate) is not None
+    return extract_answer(candidate, prompt=prompt) is not None
 
 
 verify.claims = claims  # type: ignore[attr-defined]
+
+
+# ------------------------------------------------------------------ equivalence
+
+
+def _parse_number(s: str) -> float | None:
+    """Parse ``s`` as a float. Accepts plain decimals, comma grouping, and
+    simple ``a/b`` fractions. Returns ``None`` on any parse failure."""
+    if s is None:
+        return None
+    s = str(s).strip().replace(",", "")
+    if not s:
+        return None
+    if "/" in s:
+        try:
+            num, den = s.split("/", 1)
+            d = float(den)
+            if d == 0.0:
+                return None
+            return float(num) / d
+        except (TypeError, ValueError):
+            return None
+    try:
+        return float(s)
+    except (TypeError, ValueError):
+        return None
+
+
+def answers_match(
+    reference: object,
+    candidate_answer: object,
+    *,
+    rtol: float = 1e-3,
+    abs_tol: float = 0.0,
+) -> bool:
+    """Tolerant equivalence for math answers.
+
+    Accepts:
+
+    - Exact string match after whitespace / comma-grouping normalization.
+    - Fraction canonicalization: ``"5 / 8"`` and ``"5/8"`` are equal, and
+      a fraction like ``"5/8"`` matches its decimal equivalent ``"0.625"``
+      via the numeric path.
+    - Numeric tolerance: both sides are float-parsed and compared with
+      ``math.isclose(rel_tol=rtol, abs_tol=abs_tol)``. The default
+      ``rtol=1e-3`` reclaims mini-GSM8K misses like ``43.98`` vs
+      ``43.98226`` where the gold carries extra decimals. Eval harnesses
+      that want stricter equality can tighten via the kwarg.
+
+    Returns ``False`` for unparseable inputs or type mismatches. Never
+    raises.
+    """
+    if reference is None or candidate_answer is None:
+        return False
+    ref_s = str(reference).strip()
+    cand_s = str(candidate_answer).strip()
+    if not ref_s or not cand_s:
+        return False
+
+    # Quick win: post-normalization string compare. Handles the exact-integer
+    # and exact-fraction cases without paying the float-parse cost.
+    ref_norm = _normalize_fraction(ref_s) if "/" in ref_s else ref_s.replace(",", "")
+    cand_norm = _normalize_fraction(cand_s) if "/" in cand_s else cand_s.replace(",", "")
+    if ref_norm == cand_norm:
+        return True
+
+    # Numeric compare with the caller-specified tolerance.
+    r = _parse_number(ref_s)
+    c = _parse_number(cand_s)
+    if r is None or c is None:
+        return False
+    return math.isclose(r, c, rel_tol=rtol, abs_tol=abs_tol)

--- a/lile/tests/test_verifiers.py
+++ b/lile/tests/test_verifiers.py
@@ -18,7 +18,7 @@ import pytest
 pytestmark = pytest.mark.cpu_only
 
 from lile.objectives.verifiers import VERIFIERS, register, select, verify
-from lile.objectives.verifiers._math import extract_answer
+from lile.objectives.verifiers._math import answers_match, extract_answer
 from lile.objectives.verifiers._code import extract_code, extract_expected
 
 
@@ -99,6 +99,112 @@ def test_math_verify_none_on_non_math_prompt():
 
 def test_math_verify_false_on_no_extractable_answer():
     assert verify("math", "What is 2 + 2?", "I don't know!") is False
+
+
+# ---------------------------------------------------------------- fraction canonicalization
+#
+# Mini-GSM8K regression (2026-04-17): on tutor_run_01_40steps the verifier
+# scored 18/20; both misses were format-level. One was "5/8 vs 5" — the
+# fraction answer "#### 5/8" in the candidate got extracted as "5" because
+# the decimal regex stops at the slash. Fraction-aware extraction kicks in
+# only when the prompt asks for a fraction, keeping GSM8K-exact behaviour
+# untouched for non-fraction prompts.
+
+
+def test_extract_default_mode_splits_fraction_as_today():
+    # With no prompt hint, legacy behaviour wins: "5/8" → "5". This is the
+    # byte-stable contract for plain GSM8K short-answer extraction.
+    assert extract_answer("#### 5/8") == "5"
+
+
+def test_extract_fraction_mode_keeps_denominator():
+    """The mini-GSM8K miss: 'what fraction ...?' with candidate '#### 5/8'
+    must now extract '5/8', not '5'."""
+    prompt = "What fraction of the pizza did she eat?"
+    assert extract_answer("So she ate 5/8. #### 5/8", prompt=prompt) == "5/8"
+
+
+def test_extract_fraction_mode_handles_boxed_and_answer_label():
+    prompt = "Express your answer as a fraction."
+    assert extract_answer("so we get \\boxed{3/4}.", prompt=prompt) == "3/4"
+    assert extract_answer("Answer: 7/12", prompt=prompt) == "7/12"
+
+
+def test_extract_fraction_mode_falls_back_to_last_fraction():
+    """No anchored fraction, but the response contains one — grab it."""
+    prompt = "Give the answer as a fraction in lowest terms."
+    assert extract_answer("It's simply 2/3.", prompt=prompt) == "2/3"
+
+
+def test_extract_fraction_mode_falls_back_to_decimal_if_no_fraction():
+    """Fraction mode but the candidate didn't produce a fraction: fall
+    through to the decimal pattern rather than returning None. Keeps the
+    verifier useful when the model ignores the formatting instruction."""
+    prompt = "What fraction of the pie is left?"
+    assert extract_answer("#### 1", prompt=prompt) == "1"
+
+
+def test_extract_fraction_mode_ignores_date_like_slashes():
+    """Word-boundary anchor on ``_FRACTION`` shouldn't match dates."""
+    prompt = "What fraction?"
+    # 3/4/2020 is a date, not a fraction answer; candidate has nothing else.
+    assert extract_answer("The date was 3/4/2020.", prompt=prompt) is None
+
+
+def test_extract_fraction_prompt_hint_is_narrow():
+    """'fraction' appearing incidentally in the prompt doesn't flip mode."""
+    # No answer-shape directive — stay in decimal mode and split "5/8" → "5".
+    prompt = "Give the decimal equivalent of the fraction 5/8."
+    assert extract_answer("#### 5/8", prompt=prompt) == "5"
+
+
+# ---------------------------------------------------------------- answers_match
+#
+# The other mini-GSM8K miss: "43.98 vs 43.98226" — gold carried extra
+# decimals, candidate was rounded. Exact match failed; with rtol=1e-3 it
+# passes.
+
+
+@pytest.mark.parametrize("ref,cand,expected", [
+    # Precision miss from mini-GSM8K — default rtol=1e-3 reclaims it.
+    ("43.98226", "43.98", True),
+    # Fraction == decimal.
+    ("5/8", "0.625", True),
+    ("0.625", "5/8", True),
+    # Whitespace / comma grouping.
+    ("1,234", "1234", True),
+    ("5 / 8", "5/8", True),
+    # Exact integers.
+    ("7", "7", True),
+    # Real mismatches stay false under default rtol.
+    ("42", "43", False),
+    ("5/8", "3/8", False),
+    # Unparseable strings compare False, not raise.
+    ("foo", "bar", False),
+    ("7", "seven", False),
+    # Division by zero in a fraction → False, not raise.
+    ("1/0", "1", False),
+])
+def test_answers_match_default_rtol(ref, cand, expected):
+    assert answers_match(ref, cand) is expected
+
+
+def test_answers_match_tighter_rtol_rejects_loose_matches():
+    """Harness can tighten rtol for promotion-grade evals."""
+    # With rtol=1e-3 this matches; at rtol=1e-6 it doesn't.
+    assert answers_match("43.98226", "43.98", rtol=1e-3) is True
+    assert answers_match("43.98226", "43.98", rtol=1e-6) is False
+
+
+def test_answers_match_abs_tol_handles_near_zero():
+    """rtol alone is useless around zero; abs_tol is the escape hatch."""
+    assert answers_match("0", "0.0001") is False
+    assert answers_match("0", "0.0001", abs_tol=1e-3) is True
+
+
+def test_answers_match_none_inputs_return_false():
+    assert answers_match(None, "5") is False
+    assert answers_match("5", None) is False
 
 
 # ---------------------------------------------------------------- code


### PR DESCRIPTION
## Summary

Reclaims the two format-level misses from the 2026-04-17 mini-GSM8K run on `tutor_run_01_40steps` (18/20 → 20/20 on the same prompts) without retraining. Lead-scoped per PR #33 shape — minimal surface.

1. **Fraction canonicalization in `extract_answer`.** `extract_answer` now takes an optional `prompt` kwarg. When the prompt has an explicit fraction directive (*what fraction*, *as a fraction*, *in lowest/simplest terms*), fraction `a/b` patterns anchored on `####` / `\boxed{}` / `answer:` are tried first, then an unanchored last-`a/b` scan with date-safe word boundaries. Default behaviour (no prompt hint) is byte-stable — `extract_answer("#### 5/8") == "5"` still holds.

2. **`answers_match(reference, candidate, *, rtol=1e-3, abs_tol=0.0)`.** New public primitive in `lile.objectives.verifiers._math`. Exact-string → fraction-canonical-string → `math.isclose` numeric compare. Default `rtol=1e-3` reclaims *43.98 vs 43.98226*; the harness tightens via kwarg for promotion-grade evals.

3. **`verify("math", prompt, candidate)`** now forwards `prompt=` to `extract_answer`, so TTRL benefits from fraction-aware extraction automatically.

## Regression evidence

Quick end-to-end simulation of the two mini-GSM8K misses under the new code:

```
fraction case: extracted='5/8', match=True
precision case: extracted='43.98', match=True
```

Both flip from fail to pass.

## Design choices worth calling out

- **Fraction-mode fallthrough is anchored-only.** If the prompt asks for a fraction but the candidate only emitted an integer (e.g. `#### 1`), we fall through to the decimal anchors, but *not* to the last-number-anywhere scan. That scan was grabbing `2020` out of dates like `3/4/2020` — pinned with a test.
- **Fraction prompt hint is narrow on purpose.** Just *"fraction"* in the prompt isn't enough — the regex requires an explicit answer-shape directive, so "the decimal equivalent of the fraction 5/8" doesn't flip mode.
- **`answers_match` never raises.** Unparseable strings, `1/0`, and `None` all return `False`. Adapters shouldn't take down callers.

## Test plan

- [x] `python -m pytest lile/tests/test_verifiers.py` — 47 passed (21 new)
- [x] `python -m pytest lile/tests -m cpu_only` — 214 passed, 0 failed
- [x] End-to-end sim of the two mini-GSM8K misses confirms both flip to pass
- [ ] CI (runs on push)

## Out of scope

- Wiring `answers_match` into `lile/teach/eval.py` and the `tutor_run_01_40steps` re-run. That's a separate small op once the lead re-runs mini-GSM8K under the new matcher.
- Conftest whitelist self-validation (lead's #37 review item); filing for a dedicated follow-up PR so its failure modes don't tangle with this patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)