### PR TITLE
ship lile in the Studio Docker image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,6 +10,7 @@ on:
       - 'studio/**'
       - 'unsloth/**'
       - 'unsloth_cli/**'
+      - 'lile/**'
       - 'pyproject.toml'
   workflow_dispatch:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,26 @@ RUN mkdir -p /opt/unsloth/.venv_t5 \
     && /opt/unsloth/.venv/bin/python -m pip install --target /opt/unsloth/.venv_t5 --no-deps \
        "transformers==5.3.0" "huggingface_hub==1.3.0"
 
+# Install the lile LiveLearn daemon's one extra runtime dep. The Studio
+# venv already ships fastapi / uvicorn / starlette / pydantic / safetensors,
+# but prometheus_client is lile-only. With this line, the image can run
+# either surface:
+#
+#   # Default: Studio on :8000
+#   docker run --gpus all -p 8000:8000 marksverdhei/ht-unsloth-studio
+#
+#   # Override to run the lile LiveLearn daemon on :8765. ServeConfig has no
+#   # argparse yet (pending prod/server-argparse), so we bind host/port via
+#   # a one-liner until that lands.
+#   docker run --gpus all -p 8765:8765 marksverdhei/ht-unsloth-studio \
+#     /opt/unsloth/.venv/bin/python -c \
+#     "from lile.config import ServeConfig; from lile.server import serve; \
+#      serve(ServeConfig(host='0.0.0.0', port=8765))"
+#
+# lile's source is already present from the COPY above — it's importable
+# as a top-level package from /opt/unsloth.
+RUN /opt/unsloth/.venv/bin/python -m pip install "prometheus_client>=0.20"
+
 # Build frontend
 RUN cd studio/frontend && npm install && npm run build
 RUN cd studio/backend/core/data_recipe/oxc-validator && npm install


### PR DESCRIPTION
## Summary

Lile's runtime deps are almost entirely a subset of Studio's: fastapi, uvicorn, starlette, pydantic, safetensors — all already installed in the Studio venv. The only gap is `prometheus_client`. Adding one `pip install` line teaches the existing `marksverdhei/ht-unsloth-studio` image to run the LiveLearn daemon as an alternate entrypoint — no second image, no parallel build pipeline.

Also widens the docker-publish workflow path filter to include `lile/**` so daemon-only changes rebuild the image (before this, a pure-lile PR could merge without the image picking it up).

## Changes

- `Dockerfile`: one `pip install prometheus_client>=0.20` into the Studio venv, with a block comment showing both entrypoints (default Studio CMD unchanged; lile runs via a one-liner until `prod/server-argparse` gives the daemon a real CLI).
- `.github/workflows/docker-publish.yml`: add `lile/**` to the path trigger.

## Test plan

- [x] `pip index versions prometheus_client` — pinnable, latest 0.25.0
- [x] `grep` all of lile's third-party imports; only prometheus_client is not already in Studio's requirements
- [ ] CI build+push completes (watch after merge — matches existing automation)
- [ ] `docker run …/ht-unsloth-studio /opt/unsloth/.venv/bin/python -c "import lile.server"` — smoke-import once the image is published

🤖 Generated with [Claude Code](https://claude.com/claude-code)