### PR TITLE
feat(lile): kl_anchor target_position scope + per-sample exclude (task #15)

### DIFF
--- a/lile/objectives/kl.py
+++ b/lile/objectives/kl.py
@@ -3,6 +3,21 @@
 Computes KL( π_θ(·|x) || π_ref(·|x) ) averaged over sample positions. Requires
 a reference model passed in. For the daemon this is typically the base model
 (LoRA turned off) or an EMA/snapshot policy.
+
+Scopes
+------
+
+- ``scope="prompt"`` — default; anchor over prompt tokens.
+- ``scope="full_sequence"`` — anchor prompt + first available response-like
+  field.
+- ``scope="target_position"`` — single-position anchor at each sample's last
+  real token position, with caller-chosen token IDs excluded from the KL
+  domain. Built for composition with ``unlike`` (single-position push-down):
+  excluding the surgery tokens lets them move freely while the KL pins the
+  rest of the vocab at that position. Schema fallback derives the exclude
+  set per-sample from ``{bad_token_id, good_token_id}`` when the caller has
+  not set ``exclude_token_ids`` explicitly; explicit + per-sample are
+  UNIONed so a batch-level list widens (never shrinks) the derived one.
 """
 from __future__ import annotations
 
@@ -10,6 +25,8 @@ from typing import Any
 
 import torch
 import torch.nn.functional as F
+
+from ._utils import _to_int_list
 
 
 _RESPONSE_FIELDS = ("response", "good", "chosen", "better_response")
@@ -44,7 +61,158 @@ def _sample_text(s: dict[str, Any], scope: str) -> str:
             if isinstance(v, str) and v:
                 return prompt + v
         return prompt
+    if scope == "target_position":
+        # target_position is not a text-based scope — the caller uses the
+        # dedicated target-position branch in ``kl_anchor_loss``. Surfacing
+        # this here would hide that mis-routing; raise loudly so the top-level
+        # dispatch stays honest.
+        raise ValueError(
+            "scope='target_position' does not map to a text slice; "
+            "kl_anchor_loss handles it via a dedicated branch"
+        )
     raise ValueError(f"unknown kl scope {scope!r}")
+
+
+def _derive_exclude_ids(
+    samples: list[dict[str, Any]],
+    explicit: list[int] | None,
+) -> list[set[int]]:
+    """Per-sample exclude-set, UNION of explicit batch list + schema fallback.
+
+    The schema fallback derives ``{bad_token_id, good_token_id}`` when they
+    live on the sample (the ``unlike`` schema). Missing fields are simply
+    not contributed — the caller controls whether the surgery tokens
+    actually exist on each sample.
+    """
+    explicit_set = set(_to_int_list(explicit)) if explicit else set()
+    out: list[set[int]] = []
+    for s in samples:
+        per_sample: set[int] = set(explicit_set)
+        for field in ("bad_token_id", "good_token_id"):
+            v = s.get(field)
+            if v is None:
+                continue
+            per_sample.add(int(v))
+        out.append(per_sample)
+    return out
+
+
+def _tokenize_prefixes_with_last_idx(
+    tokenizer: Any, samples: list[dict[str, Any]],
+) -> dict[str, torch.Tensor]:
+    """Build ``(input_ids, attention_mask, last_idx)`` for target-position KL.
+
+    Mirrors the unlike objective's prefix-padding layout so that when unlike
+    and this scope land in the same batch, the two forward passes share
+    identical token geometry. Schema: uses ``prefix`` if present, otherwise
+    falls back to ``prompt`` (consistent with ``_sample_text``).
+    """
+    pad_id = tokenizer.pad_token_id or tokenizer.eos_token_id or 0
+    tokenized: list[list[int]] = []
+    for s in samples:
+        text = s.get("prefix") or s.get("prompt") or ""
+        if getattr(tokenizer, "chat_template", None):
+            raw = tokenizer.apply_chat_template(
+                [{"role": "user", "content": text}],
+                add_generation_prompt=True, tokenize=True, return_tensors=None,
+            )
+            ids = _to_int_list(raw)
+        else:
+            ids = _to_int_list(
+                tokenizer(text=text, add_special_tokens=False).input_ids,
+            )
+        if not ids:
+            # Empty prefix → one pad token so the forward still has a last
+            # position to gather from. Produces a logits row but the KL at
+            # that position is computed against the ref's same position —
+            # the degenerate case cancels to ~0 without crashing.
+            ids = [pad_id]
+        tokenized.append(ids)
+    max_len = max(len(t) for t in tokenized)
+    b = len(tokenized)
+    ids = torch.full((b, max_len), pad_id, dtype=torch.long)
+    attn = torch.zeros((b, max_len), dtype=torch.long)
+    last_idx = torch.zeros((b,), dtype=torch.long)
+    for i, t in enumerate(tokenized):
+        n = len(t)
+        ids[i, :n] = torch.tensor(t, dtype=torch.long)
+        attn[i, :n] = 1
+        last_idx[i] = n - 1
+    return {"input_ids": ids, "attention_mask": attn, "last_idx": last_idx}
+
+
+def _target_position_kl(
+    model: Any, tokenizer: Any, samples: list[dict[str, Any]],
+    pi_ref: Any | None, use_self_ref: bool, weight: float,
+    exclude_ids_per_sample: list[set[int]],
+) -> dict[str, Any]:
+    """Single-position KL at each sample's last real token, masking out
+    caller-supplied exclude IDs before renormalizing.
+
+    KL( π_ref || π_θ ) is the direction the existing anchor uses (log_p =
+    log π_θ, log_q = log π_ref, compute ``p * (log_p - log_q)`` with
+    ``p = π_θ``). Keep the same direction here so ``scope="target_position"``
+    is a drop-in narrower scope, not a different loss.
+    """
+    if not samples:
+        raise ValueError("kl_anchor_loss requires at least one sample")
+    batch = _tokenize_prefixes_with_last_idx(tokenizer, samples)
+    device = next(model.parameters()).device
+    input_ids = batch["input_ids"].to(device)
+    attn = batch["attention_mask"].to(device)
+    last_idx = batch["last_idx"].to(device)
+
+    logits = model(input_ids=input_ids, attention_mask=attn,
+                   use_cache=False).logits                                 # (B,T,V)
+    with torch.no_grad():
+        if use_self_ref:
+            with model.disable_adapter():
+                ref_logits = model(input_ids=input_ids, attention_mask=attn,
+                                   use_cache=False).logits
+        else:
+            ref_logits = pi_ref(input_ids=input_ids,
+                                attention_mask=attn, use_cache=False).logits
+
+    B, _T, V = logits.size()
+    row_idx = torch.arange(B, device=device)
+    last_logits = logits[row_idx, last_idx].float()                        # (B,V)
+    last_ref = ref_logits[row_idx, last_idx].float()                       # (B,V)
+
+    # Build per-row exclude mask then mask-fill -inf on BOTH distributions
+    # before the softmax so the renormalization is over the same un-excluded
+    # vocab on each side — otherwise KL(p||q) mixes supports and is not a
+    # valid divergence.
+    exclude_mask = torch.zeros((B, V), dtype=torch.bool, device=device)
+    excluded_total = 0
+    for i, ex in enumerate(exclude_ids_per_sample):
+        for tid in ex:
+            if 0 <= tid < V:
+                exclude_mask[i, tid] = True
+                excluded_total += 1
+    neg_inf = torch.finfo(last_logits.dtype).min
+    masked_logits = last_logits.masked_fill(exclude_mask, neg_inf)
+    masked_ref = last_ref.masked_fill(exclude_mask, neg_inf)
+
+    log_p = F.log_softmax(masked_logits, dim=-1)                           # π_θ
+    log_q = F.log_softmax(masked_ref, dim=-1)                              # π_ref
+    p = log_p.exp()
+    # Multiply by ``~exclude_mask`` before the sum so any residual mass that
+    # the finite-precision softmax assigned to -inf rows is zeroed — not
+    # strictly necessary (softmax(-inf)=0) but cheap belt-and-suspenders.
+    kl_per_token = p * (log_p - log_q)
+    kl_per_token = kl_per_token.masked_fill(exclude_mask, 0.0)
+    kl_per_row = kl_per_token.sum(dim=-1)                                  # (B,)
+    kl_mean = kl_per_row.mean()
+    loss = weight * kl_mean
+    return {
+        "loss": loss,
+        "components": {
+            "kl": float(kl_mean.detach().cpu()),
+            "kl_weight": weight,
+            "kl_scope": "target_position",
+            "kl_excluded_total": excluded_total,
+        },
+    }
 
 
 def kl_anchor_loss(model: Any, tokenizer: Any, samples: list[dict[str, Any]],
@@ -52,6 +220,7 @@ def kl_anchor_loss(model: Any, tokenizer: Any, samples: list[dict[str, Any]],
                    max_len: int = 512,
                    pi_ref_mode: str | None = "adapter_disabled",
                    scope: str = "prompt",
+                   exclude_token_ids: list[int] | None = None,
                    **_: Any) -> dict[str, Any]:
     # If no external pi_ref is provided, fall back to the LoRA-disabled path on
     # the same model (standard PEFT context manager). Only bail out to a no-op
@@ -64,6 +233,14 @@ def kl_anchor_loss(model: Any, tokenizer: Any, samples: list[dict[str, Any]],
                 "components": {"kl": 0.0, "kl_weight": weight, "kl_scope": scope}}
     if not samples:
         raise ValueError("kl_anchor_loss requires at least one sample")
+
+    if scope == "target_position":
+        exclude_per_sample = _derive_exclude_ids(samples, exclude_token_ids)
+        return _target_position_kl(
+            model=model, tokenizer=tokenizer, samples=samples,
+            pi_ref=pi_ref, use_self_ref=use_self_ref, weight=weight,
+            exclude_ids_per_sample=exclude_per_sample,
+        )
 
     texts = [_sample_text(s, scope) for s in samples]
     tok = tokenizer(text=texts, return_tensors="pt", padding=True, truncation=True,

--- a/lile/tests/test_kl_target_position.py
+++ b/lile/tests/test_kl_target_position.py
@@ -1,0 +1,282 @@
+"""Task #15 — kl_anchor scope='target_position' + per-sample exclude fallback.
+
+Covers the 5 test obligations from
+``lile/docs/research/pr-specs/kl-anchor-target-position-scope.md``:
+
+1. Schema fallback parity (per-sample derivation == explicit list).
+2. Explicit-list union with per-sample derivation.
+3. No-exclude fallback (empty exclude ⇒ standard target-position anchor).
+4. Gradient zero on excluded token logits at the target position.
+5. Existing prompt/full_sequence scopes unchanged (regression guard).
+
+The tests run on CPU against a tiny stub model that produces logits with
+the same shape contract the real model path uses (``.logits`` attr,
+``(B, T, V)`` tensor, accepts ``input_ids``/``attention_mask``/``use_cache``
+kwargs). Keeps the test cpu_only without needing a HF model in the cache.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from lile.objectives.kl import (
+    _derive_exclude_ids,
+    _sample_text,
+    kl_anchor_loss,
+)
+
+pytestmark = pytest.mark.cpu_only
+
+
+# --- stubs ------------------------------------------------------------------
+
+V = 32  # vocab size — small so the tests stay fast
+
+
+@dataclass
+class _StubOut:
+    logits: torch.Tensor
+
+
+class _StubModel(nn.Module):
+    """Minimal model-shape: embed → linear → logits.
+
+    Accepts the same kwargs the real path uses and returns an object with
+    ``.logits``. Supports ``disable_adapter()`` as a no-op context manager
+    so the ``use_self_ref`` branch in ``kl_anchor_loss`` can exercise the
+    LoRA-disabled path without needing peft.
+    """
+
+    def __init__(self, vocab_size: int = V, d: int = 16, seed: int = 0) -> None:
+        super().__init__()
+        g = torch.Generator().manual_seed(seed)
+        self.embed = nn.Embedding(vocab_size, d)
+        self.head = nn.Linear(d, vocab_size)
+        # Deterministic init so tests don't flake across runs.
+        with torch.no_grad():
+            self.embed.weight.copy_(torch.randn(vocab_size, d, generator=g))
+            self.head.weight.copy_(torch.randn(vocab_size, d, generator=g) * 0.1)
+            self.head.bias.zero_()
+
+    def forward(
+        self, input_ids: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+        use_cache: bool = False, **_: Any,
+    ) -> _StubOut:
+        h = self.embed(input_ids)
+        return _StubOut(logits=self.head(h))
+
+    def disable_adapter(self):  # noqa: D401
+        class _Noop:
+            def __enter__(self_inner) -> None: return None
+            def __exit__(self_inner, *a) -> None: return None
+        return _Noop()
+
+
+class _StubTokenizer:
+    """Minimal tokenizer: hash-based deterministic token ids, no chat template.
+
+    ``apply_chat_template`` is intentionally absent so ``_tokenize_prefixes_with_last_idx``
+    takes the plain-tokenize path (``tokenizer(text=…).input_ids``). That
+    keeps the test independent of any HF template logic.
+    """
+    pad_token_id = 0
+    eos_token_id = 0
+
+    def __call__(self, text: str = "", add_special_tokens: bool = False, **_: Any):
+        class _Enc:
+            pass
+        e = _Enc()
+        # Deterministic token ids — one per char, modulo vocab size.
+        ids = [((ord(c) % (V - 1)) + 1) for c in text]  # avoid id=0 (pad)
+        if not ids:
+            ids = [1]
+        e.input_ids = torch.tensor(ids, dtype=torch.long)
+        return e
+
+
+# --- obligation 1: schema-fallback parity -----------------------------------
+
+def test_schema_fallback_matches_explicit_exclude() -> None:
+    """Per-sample {bad, good} via schema == explicit [bad, good] at batch level."""
+    torch.manual_seed(0)
+    m = _StubModel(seed=7)
+    tok = _StubTokenizer()
+    # Use distinct IDs far from any hash-token ID so excluding them
+    # measurably changes the KL.
+    samples = [{"prefix": "abc", "bad_token_id": 10, "good_token_id": 20}]
+
+    loss_fallback = kl_anchor_loss(
+        m, tok, samples, scope="target_position", weight=1.0,
+    )
+    loss_explicit = kl_anchor_loss(
+        m, tok, samples, scope="target_position", weight=1.0,
+        exclude_token_ids=[10, 20],
+    )
+    a = float(loss_fallback["loss"].detach())
+    b = float(loss_explicit["loss"].detach())
+    assert abs(a - b) < 1e-6, (a, b)
+
+
+# --- obligation 2: explicit + per-sample union ------------------------------
+
+def test_explicit_list_unions_with_per_sample() -> None:
+    excluded = _derive_exclude_ids(
+        [{"bad_token_id": 10, "good_token_id": 20}],
+        explicit=[30],
+    )
+    assert excluded == [{10, 20, 30}]
+
+
+def test_explicit_union_is_visible_in_components() -> None:
+    """Wider exclude set ⇒ more excluded tokens reported."""
+    m = _StubModel(seed=1)
+    tok = _StubTokenizer()
+    samples = [{"prefix": "abc", "bad_token_id": 5, "good_token_id": 7}]
+
+    narrow = kl_anchor_loss(
+        m, tok, samples, scope="target_position", weight=1.0,
+    )
+    wider = kl_anchor_loss(
+        m, tok, samples, scope="target_position", weight=1.0,
+        exclude_token_ids=[11, 12, 13],
+    )
+    assert narrow["components"]["kl_excluded_total"] == 2
+    assert wider["components"]["kl_excluded_total"] == 5
+
+
+# --- obligation 3: no-exclude fallback --------------------------------------
+
+def test_no_exclude_runs_over_full_vocab() -> None:
+    """Samples without bad/good + no explicit exclude → anchor over full vocab.
+
+    The KL should be ~0 since the model equals itself (same path taken via
+    ``use_self_ref``) — we only require the call completes and returns a
+    sensible-shaped loss without raising.
+    """
+    m = _StubModel(seed=2)
+    tok = _StubTokenizer()
+    samples = [{"prefix": "hi"}]
+
+    out = kl_anchor_loss(
+        m, tok, samples, scope="target_position", weight=1.0,
+    )
+    assert out["components"]["kl_excluded_total"] == 0
+    assert out["loss"].dim() == 0
+    # Self-ref path: KL(self || self) ≈ 0. Keep the threshold wide enough
+    # that softmax + float32 noise doesn't trip it.
+    assert abs(float(out["components"]["kl"])) < 1e-4
+
+
+def test_derive_exclude_ids_missing_fields() -> None:
+    """Samples without bad/good fields contribute empty to the exclude set."""
+    assert _derive_exclude_ids(
+        [{"prefix": "x"}, {"prefix": "y", "bad_token_id": 9}],
+        explicit=None,
+    ) == [set(), {9}]
+
+
+# --- obligation 4: gradient is zero on excluded logits ----------------------
+
+def test_gradient_zero_on_excluded_token_at_target_position() -> None:
+    """Backward through the target-position KL must leave the excluded token
+    IDs' logits at the target position with zero gradient.
+
+    Construct the KL with a DIFFERENT pi_ref (not self-ref) so the KL is
+    nonzero — self-ref KL is zero and would trivially satisfy the gradient
+    test. Then verify that while SOME logits get gradient, the excluded
+    slots at the target positions get exactly zero.
+    """
+    torch.manual_seed(0)
+    theta = _StubModel(seed=3)
+    ref = _StubModel(seed=4)  # distinct weights ⇒ nonzero KL
+
+    tok = _StubTokenizer()
+    samples = [
+        {"prefix": "abc", "bad_token_id": 10, "good_token_id": 20},
+        {"prefix": "def", "bad_token_id": 11},
+    ]
+    exclude_extra = [30]
+
+    out = kl_anchor_loss(
+        theta, tok, samples, pi_ref=ref,
+        scope="target_position", weight=1.0,
+        exclude_token_ids=exclude_extra,
+    )
+    # Sanity: loss is nonzero (else the gradient test is vacuous).
+    assert float(out["loss"].detach()) > 1e-6
+
+    # Hook to capture the final logits gradient at the target position.
+    # The cleanest way: re-run the forward and register a hook so we can
+    # inspect the gradient on the logits tensor itself.
+    #
+    # Rebuild the batch the same way kl_anchor_loss does (import the helper).
+    from lile.objectives.kl import _tokenize_prefixes_with_last_idx
+    batch = _tokenize_prefixes_with_last_idx(tok, samples)
+    ids = batch["input_ids"]
+    attn = batch["attention_mask"]
+    last_idx = batch["last_idx"]
+
+    logits = theta(input_ids=ids, attention_mask=attn).logits
+    logits.retain_grad()
+    with torch.no_grad():
+        ref_logits = ref(input_ids=ids, attention_mask=attn).logits
+
+    B, _T, Vv = logits.size()
+    row_idx = torch.arange(B)
+    last_logits = logits[row_idx, last_idx].float()
+    last_ref = ref_logits[row_idx, last_idx].float()
+
+    exclude_sets = [{10, 20, 30}, {11, 30}]
+    exclude_mask = torch.zeros((B, Vv), dtype=torch.bool)
+    for i, ex in enumerate(exclude_sets):
+        for tid in ex:
+            exclude_mask[i, tid] = True
+
+    neg_inf = torch.finfo(last_logits.dtype).min
+    masked_logits = last_logits.masked_fill(exclude_mask, neg_inf)
+    masked_ref = last_ref.masked_fill(exclude_mask, neg_inf)
+    log_p = F.log_softmax(masked_logits, dim=-1)
+    log_q = F.log_softmax(masked_ref, dim=-1)
+    p = log_p.exp()
+    kl = (p * (log_p - log_q)).masked_fill(exclude_mask, 0.0).sum(dim=-1).mean()
+    kl.backward()
+
+    assert logits.grad is not None
+    grad_at_last = logits.grad[row_idx, last_idx]
+    for i, ex in enumerate(exclude_sets):
+        for tid in ex:
+            g = float(grad_at_last[i, tid])
+            assert g == 0.0, f"sample {i} excluded token {tid} got grad {g}"
+    # At least one non-excluded slot must have gotten SOME gradient for
+    # the test to be non-vacuous.
+    non_excluded = ~exclude_mask
+    nonzero = grad_at_last[non_excluded].abs().max().item()
+    assert nonzero > 0.0, "no gradient flowed at all — test is vacuous"
+
+
+# --- obligation 5: existing scopes unchanged --------------------------------
+
+def test_scope_prompt_still_routes_through_sample_text() -> None:
+    """Regression: prompt scope still hits the text branch, unchanged shape."""
+    assert _sample_text({"prompt": "Q:"}, "prompt") == "Q:"
+
+
+def test_scope_full_sequence_still_routes_through_sample_text() -> None:
+    assert _sample_text({"prompt": "Q:", "response": "A"}, "full_sequence") == "Q:A"
+
+
+def test_target_position_text_lookup_raises() -> None:
+    """target_position must not silently degrade to a text scope.
+
+    ``_sample_text`` must raise when called with target_position so the
+    top-level dispatch in ``kl_anchor_loss`` stays the single routing
+    point for the new scope.
+    """
+    with pytest.raises(ValueError, match="target_position"):
+        _sample_text({"prompt": "Q:"}, "target_position")


### PR DESCRIPTION
## Summary
- Adds `scope="target_position"` to `kl_anchor` — single-position KL at each sample's last real token with caller-chosen token IDs masked out before renormalization
- Adds `exclude_token_ids` param; per-sample schema fallback derives `{bad_token_id, good_token_id}`; explicit batch list UNIONs with the per-sample set
- `_sample_text("target_position")` raises so routing into the new branch stays loud
- Shares prefix-padding + `last_idx` layout with `unlike` (kl-local helper, no cross-module import) so mixed batches see identical token geometry
- Unblocks task #19 (unlike tiered preconditions)

Spec: `lile/docs/research/pr-specs/kl-anchor-target-position-scope.md`

## Test plan
- [x] `pytest lile/tests/test_kl_target_position.py` — 9 passed, cpu_only. Covers all 5 spec obligations against a stub torch module (no HF model cache needed)
- [x] `pytest lile/tests/test_kl_scope.py` — 10 passed, regression guard on existing `prompt`/`full_sequence` scopes
- [ ] End-to-end integration with real model + composed `unlike` batch (deferred — picked up by `smoke_objectives.py` once task #19 tiered preconditions land and the canonical unlike+anchor composition is exercised)

🤖 Generated with [Claude Code](https://claude.com/claude-code)