### PR TITLE
lile: server CLI flags + metrics follow-ups (cherry-pick from #21, #31)

### DIFF
--- a/lile/cli.py
+++ b/lile/cli.py
@@ -1,0 +1,45 @@
+"""CLI argument parsing for ``python -m lile.server``.
+
+Lives outside ``lile.server`` so it can be imported (and tested) without
+pulling in uvicorn / transformers / torch — keeping the cpu_only / torchless
+test runner happy.
+"""
+from __future__ import annotations
+
+import argparse
+import pathlib
+
+from .config import ServeConfig
+
+
+def parse_cli_args(argv: list[str] | None = None) -> ServeConfig:
+    """Parse argv into a ServeConfig, overriding only fields the user set."""
+    cfg = ServeConfig()
+    p = argparse.ArgumentParser(prog="lile.server")
+    p.add_argument("--host", default=cfg.host)
+    p.add_argument("--port", type=int, default=cfg.port)
+    p.add_argument("--model", default=cfg.model)
+    p.add_argument("--data-dir", type=pathlib.Path, default=cfg.data_dir)
+    p.add_argument("--max-seq-length", type=int, default=cfg.max_seq_length)
+    p.add_argument("--lora-rank", type=int, default=cfg.lora_rank)
+    p.add_argument("--no-4bit", dest="load_in_4bit", action="store_false",
+                   default=cfg.load_in_4bit)
+    p.add_argument("--idle-replay", dest="idle_replay", action="store_true",
+                   default=cfg.idle_replay)
+    p.add_argument("--frozen-ref", dest="frozen_ref", action="store_true",
+                   default=cfg.frozen_ref)
+    args = p.parse_args(argv)
+    cfg.host = args.host
+    cfg.port = args.port
+    cfg.model = args.model
+    cfg.data_dir = args.data_dir
+    cfg.max_seq_length = args.max_seq_length
+    cfg.lora_rank = args.lora_rank
+    cfg.load_in_4bit = args.load_in_4bit
+    cfg.idle_replay = args.idle_replay
+    cfg.frozen_ref = args.frozen_ref
+    return cfg
+
+
+# Back-compat alias — older tests / external callers may still reach for this.
+_parse_cli_args = parse_cli_args

--- a/lile/metrics.py
+++ b/lile/metrics.py
@@ -26,11 +26,18 @@ from prometheus_client import (
     generate_latest,
 )
 from prometheus_client.core import GaugeMetricFamily
+from prometheus_client.exposition import CONTENT_TYPE_LATEST
+from prometheus_client.openmetrics.exposition import (
+    CONTENT_TYPE_LATEST as OPENMETRICS_CONTENT_TYPE,
+    generate_latest as generate_openmetrics,
+)
 from prometheus_client.registry import Collector
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
 from starlette.types import ASGIApp
+
+from .middleware import current_request_id
 
 log = logging.getLogger(__name__)
 
@@ -82,24 +89,26 @@ _REPLAY_ENQUEUED = Counter(
 
 # ---------------------------------------------------------------- histograms
 
-# Bucket choices: default prom buckets are tuned for web-request seconds;
-# step latency and generate latency are both naturally in the tens-of-ms
-# to multi-second range, so we use the same bucket family scaled to ms.
-_LATENCY_MS_BUCKETS = (5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 30000)
+# Prometheus convention: base units are seconds (histogram suffix ``_seconds``).
+# Buckets cover the ms-to-tens-of-seconds range both train-step and generate
+# paths actually exercise.
+_LATENCY_SECONDS_BUCKETS = (
+    0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0,
+)
 
 _STEP_LATENCY = Histogram(
-    "lile_step_latency_ms",
+    "lile_step_latency_seconds",
     "Wall-clock time spent inside TrainEngine.step.",
     labelnames=("objective",),
-    buckets=_LATENCY_MS_BUCKETS,
+    buckets=_LATENCY_SECONDS_BUCKETS,
     registry=REGISTRY,
 )
 
 _GENERATE_LATENCY = Histogram(
-    "lile_generate_latency_ms",
+    "lile_generate_latency_seconds",
     "Wall-clock time for a chat completion. stream=true means time-to-first-token.",
     labelnames=("stream",),
-    buckets=_LATENCY_MS_BUCKETS,
+    buckets=_LATENCY_SECONDS_BUCKETS,
     registry=REGISTRY,
 )
 
@@ -276,6 +285,34 @@ def render_prometheus() -> bytes:
     return generate_latest(REGISTRY)
 
 
+def render_openmetrics() -> bytes:
+    """Return the OpenMetrics text exposition (includes exemplars)."""
+    return generate_openmetrics(REGISTRY)
+
+
+def render_negotiated(accept_header: str | None) -> tuple[bytes, str]:
+    """Pick the response format based on the Accept header.
+
+    Prometheus' scraper sends ``Accept: application/openmetrics-text;…`` when
+    it wants exemplars; anything else (curl, browser probes) gets plain text.
+    Returns ``(body, content_type)``.
+    """
+    if accept_header and "application/openmetrics-text" in accept_header:
+        return render_openmetrics(), OPENMETRICS_CONTENT_TYPE
+    return render_prometheus(), CONTENT_TYPE_LATEST
+
+
+def _exemplar() -> dict[str, str] | None:
+    """Bundle the active request id as an exemplar, if one is bound.
+
+    Exemplars render only in the OpenMetrics exposition format; ``generate_latest``
+    (plain-text Prometheus) ignores them. Keeping the attribute present on every
+    observe is cheap and lets scrapers opt into exemplar-aware queries.
+    """
+    rid = current_request_id()
+    return {"request_id": rid} if rid else None
+
+
 # ---------------------------------------------------------------- hot-path hooks
 
 
@@ -286,11 +323,15 @@ def record_request(*, route: str, status: int) -> None:
 
 def record_train_step(*, objective: str, latency_s: float, loss: float | None = None) -> None:
     """Bump `lile_train_steps_total{objective}` + observe latency/loss histograms."""
-    _TRAIN_STEPS.labels(objective=objective or "unknown").inc()
-    _STEP_LATENCY.labels(objective=objective or "unknown").observe(latency_s * 1000.0)
+    objective = objective or "unknown"
+    exemplar = _exemplar()
+    _TRAIN_STEPS.labels(objective=objective).inc()
+    _STEP_LATENCY.labels(objective=objective).observe(latency_s, exemplar=exemplar)
     if loss is not None:
         try:
-            _OBJECTIVE_LOSS.labels(objective=objective or "unknown").observe(float(loss))
+            _OBJECTIVE_LOSS.labels(objective=objective).observe(
+                float(loss), exemplar=exemplar,
+            )
         except (TypeError, ValueError):  # pragma: no cover — defensive
             pass
 
@@ -313,9 +354,9 @@ def record_replay_enqueued(n: int = 1) -> None:
 
 
 def record_generate_latency(*, stream: bool, latency_s: float) -> None:
-    """Observe `lile_generate_latency_ms{stream}`. For streams this is TTFT."""
+    """Observe `lile_generate_latency_seconds{stream}`. For streams this is TTFT."""
     _GENERATE_LATENCY.labels(stream="true" if stream else "false").observe(
-        latency_s * 1000.0
+        latency_s, exemplar=_exemplar(),
     )
 
 
@@ -352,5 +393,7 @@ def _resolve_route(request: Request) -> str:
     path = getattr(route, "path", None)
     if path:
         return path
-    # Fallback for unmatched routes (404 on unknown path).
-    return request.url.path or "unknown"
+    # Collapse unmatched routes (scanners, probes, 404s) into a single label
+    # value — using ``request.url.path`` would let a hostile client mint
+    # unbounded cardinality in ``lile_requests_total``.
+    return "unmatched"

--- a/lile/server.py
+++ b/lile/server.py
@@ -14,7 +14,7 @@ import time
 from typing import Any
 
 import uvicorn
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import Response, StreamingResponse
 from pydantic import BaseModel, Field
 
@@ -132,11 +132,11 @@ def create_app(cfg: ServeConfig | None = None) -> FastAPI:
 
     # --------------------------------------------------------------- metrics
     @app.get("/metrics")
-    async def metrics_endpoint() -> Response:
-        return Response(
-            metrics_mod.render_prometheus(),
-            media_type="text/plain; version=0.0.4; charset=utf-8",
+    async def metrics_endpoint(request: Request) -> Response:
+        body, content_type = metrics_mod.render_negotiated(
+            request.headers.get("accept"),
         )
+        return Response(body, media_type=content_type)
 
     # --------------------------------------------------------------- health
     @app.get("/health")

--- a/lile/server.py
+++ b/lile/server.py
@@ -3,11 +3,13 @@
 """
 from __future__ import annotations
 
+import argparse
 import asyncio
 import contextlib
 import json
 import logging
 import os
+import pathlib
 import time
 from typing import Any
 
@@ -375,5 +377,34 @@ def serve(cfg: ServeConfig | None = None) -> None:
     uvicorn.run(app, host=app.state.cfg.host, port=app.state.cfg.port, log_level="info")
 
 
+def _parse_cli_args(argv: list[str] | None = None) -> ServeConfig:
+    """Parse argv into a ServeConfig, overriding only fields the user set."""
+    cfg = ServeConfig()
+    p = argparse.ArgumentParser(prog="lile.server", description=__doc__)
+    p.add_argument("--host", default=cfg.host)
+    p.add_argument("--port", type=int, default=cfg.port)
+    p.add_argument("--model", default=cfg.model)
+    p.add_argument("--data-dir", type=pathlib.Path, default=cfg.data_dir)
+    p.add_argument("--max-seq-length", type=int, default=cfg.max_seq_length)
+    p.add_argument("--lora-rank", type=int, default=cfg.lora_rank)
+    p.add_argument("--no-4bit", dest="load_in_4bit", action="store_false",
+                   default=cfg.load_in_4bit)
+    p.add_argument("--idle-replay", dest="idle_replay", action="store_true",
+                   default=cfg.idle_replay)
+    p.add_argument("--frozen-ref", dest="frozen_ref", action="store_true",
+                   default=cfg.frozen_ref)
+    args = p.parse_args(argv)
+    cfg.host = args.host
+    cfg.port = args.port
+    cfg.model = args.model
+    cfg.data_dir = args.data_dir
+    cfg.max_seq_length = args.max_seq_length
+    cfg.lora_rank = args.lora_rank
+    cfg.load_in_4bit = args.load_in_4bit
+    cfg.idle_replay = args.idle_replay
+    cfg.frozen_ref = args.frozen_ref
+    return cfg
+
+
 if __name__ == "__main__":
-    serve()
+    serve(_parse_cli_args())

--- a/lile/server.py
+++ b/lile/server.py
@@ -3,13 +3,11 @@
 """
 from __future__ import annotations
 
-import argparse
 import asyncio
 import contextlib
 import json
 import logging
 import os
-import pathlib
 import time
 from typing import Any
 
@@ -377,34 +375,6 @@ def serve(cfg: ServeConfig | None = None) -> None:
     uvicorn.run(app, host=app.state.cfg.host, port=app.state.cfg.port, log_level="info")
 
 
-def _parse_cli_args(argv: list[str] | None = None) -> ServeConfig:
-    """Parse argv into a ServeConfig, overriding only fields the user set."""
-    cfg = ServeConfig()
-    p = argparse.ArgumentParser(prog="lile.server", description=__doc__)
-    p.add_argument("--host", default=cfg.host)
-    p.add_argument("--port", type=int, default=cfg.port)
-    p.add_argument("--model", default=cfg.model)
-    p.add_argument("--data-dir", type=pathlib.Path, default=cfg.data_dir)
-    p.add_argument("--max-seq-length", type=int, default=cfg.max_seq_length)
-    p.add_argument("--lora-rank", type=int, default=cfg.lora_rank)
-    p.add_argument("--no-4bit", dest="load_in_4bit", action="store_false",
-                   default=cfg.load_in_4bit)
-    p.add_argument("--idle-replay", dest="idle_replay", action="store_true",
-                   default=cfg.idle_replay)
-    p.add_argument("--frozen-ref", dest="frozen_ref", action="store_true",
-                   default=cfg.frozen_ref)
-    args = p.parse_args(argv)
-    cfg.host = args.host
-    cfg.port = args.port
-    cfg.model = args.model
-    cfg.data_dir = args.data_dir
-    cfg.max_seq_length = args.max_seq_length
-    cfg.lora_rank = args.lora_rank
-    cfg.load_in_4bit = args.load_in_4bit
-    cfg.idle_replay = args.idle_replay
-    cfg.frozen_ref = args.frozen_ref
-    return cfg
-
-
 if __name__ == "__main__":
-    serve(_parse_cli_args())
+    from .cli import parse_cli_args
+    serve(parse_cli_args())

--- a/lile/tests/conftest.py
+++ b/lile/tests/conftest.py
@@ -46,6 +46,7 @@ _TORCHLESS_OK = {
     "test_trajectory_tail.py",      # lile.trajectory is pure Python
     "test_whitelist_consistency.py", # self-validation of _TORCHLESS_OK
     "test_commits_sse_stream.py",   # lile.commit_stream is pure asyncio + FastAPI
+    "test_server_cli.py",           # argparse-only — no torch import
     "conftest.py",
     "__init__.py",
 }

--- a/lile/tests/test_metrics.py
+++ b/lile/tests/test_metrics.py
@@ -4,7 +4,7 @@ Covers `lile/metrics.py`:
 
 - Counters (requests_total, train_steps_total, feedback_events_total,
   queue_dropped_total, replay_enqueued_total).
-- Histograms (step_latency_ms, generate_latency_ms, objective_loss).
+- Histograms (step_latency_seconds, generate_latency_seconds, objective_loss).
 - Lazy gauges (queue_depth, commit_cursor, merges_applied, trajectory_bytes,
   snapshots_bytes, snapshots_count, shutting_down) sampled from a bound
   Controller-shaped object at scrape time.
@@ -123,7 +123,7 @@ def test_record_train_step_increments_counter_and_histogram():
     after = _counter_value(text.encode(), "lile_train_steps_total", {"objective": "sft"})
     assert after == before + 1.0
     # Histogram count bumped.
-    assert "lile_step_latency_ms_count" in text
+    assert "lile_step_latency_seconds_count" in text
 
 
 def test_record_feedback_event_counter():
@@ -143,8 +143,8 @@ def test_record_generate_latency_observes_histogram():
     metrics.record_generate_latency(stream=False, latency_s=0.25)
     metrics.record_generate_latency(stream=True, latency_s=0.05)
     text = metrics.render_prometheus().decode("utf-8")
-    assert 'lile_generate_latency_ms_count{stream="false"}' in text
-    assert 'lile_generate_latency_ms_count{stream="true"}' in text
+    assert 'lile_generate_latency_seconds_count{stream="false"}' in text
+    assert 'lile_generate_latency_seconds_count{stream="true"}' in text
 
 
 # ---------------------------------------------------------------- gauges (lazy)
@@ -229,6 +229,58 @@ def test_metrics_route_emits_prom_text_format():
     assert r.headers["content-type"].startswith("text/plain")
     assert r.text.startswith("#") or r.text.lstrip().startswith("#")
     assert "lile_requests_total" in r.text
+
+
+def test_openmetrics_negotiation_returns_exemplar_content_type():
+    """Prometheus' scraper sends Accept: application/openmetrics-text to opt
+    into exemplars. Plain-text callers keep the legacy content-type."""
+    from lile import metrics
+
+    plain_body, plain_ct = metrics.render_negotiated(
+        "text/plain; version=0.0.4"
+    )
+    assert plain_ct.startswith("text/plain")
+    assert b"# HELP lile_requests_total" in plain_body
+
+    om_body, om_ct = metrics.render_negotiated(
+        "application/openmetrics-text; version=1.0.0; charset=utf-8"
+    )
+    assert om_ct.startswith("application/openmetrics-text")
+    # The OpenMetrics exposition has a distinctive `# EOF` trailer.
+    assert b"# EOF" in om_body
+
+
+def test_exemplar_attached_when_request_id_bound():
+    """Observing inside a bound request-id context should emit an exemplar in
+    the OpenMetrics exposition."""
+    from lile.middleware import _REQUEST_ID_CTX, set_request_id
+    from lile import metrics
+
+    token = set_request_id("req_cafebabecafebabe")
+    try:
+        metrics.record_train_step(objective="sft", latency_s=0.01, loss=0.5)
+    finally:
+        _REQUEST_ID_CTX.reset(token)
+
+    body = metrics.render_openmetrics().decode("utf-8")
+    assert "request_id=\"req_cafebabecafebabe\"" in body
+
+
+def test_unmatched_route_collapses_to_single_label():
+    """Unknown paths must not mint unbounded route= label cardinality."""
+    from starlette.datastructures import URL
+
+    from lile import metrics
+
+    class _FakeRequest:
+        def __init__(self, path: str) -> None:
+            self.scope = {}
+            self.url = URL(path)
+
+    # Any unmatched path (scanner probes, typos, 404s) collapses to one label.
+    assert metrics._resolve_route(_FakeRequest("/admin")) == "unmatched"
+    assert metrics._resolve_route(_FakeRequest("/..%2fsecret")) == "unmatched"
+    assert metrics._resolve_route(_FakeRequest("/")) == "unmatched"
 
 
 def test_metrics_route_wired_in_server():

--- a/lile/tests/test_server_cli.py
+++ b/lile/tests/test_server_cli.py
@@ -15,7 +15,7 @@ pytestmark = pytest.mark.cpu_only
 
 def test_defaults_match_serve_config():
     from lile.config import ServeConfig
-    from lile.server import _parse_cli_args
+    from lile.cli import parse_cli_args as _parse_cli_args
 
     default = ServeConfig()
     cfg = _parse_cli_args([])
@@ -26,14 +26,14 @@ def test_defaults_match_serve_config():
 
 
 def test_port_flag_overrides_default():
-    from lile.server import _parse_cli_args
+    from lile.cli import parse_cli_args as _parse_cli_args
 
     cfg = _parse_cli_args(["--port", "8766"])
     assert cfg.port == 8766
 
 
 def test_host_and_model_flags_override_defaults():
-    from lile.server import _parse_cli_args
+    from lile.cli import parse_cli_args as _parse_cli_args
 
     cfg = _parse_cli_args(["--host", "0.0.0.0", "--model", "foo/bar"])
     assert cfg.host == "0.0.0.0"
@@ -41,14 +41,14 @@ def test_host_and_model_flags_override_defaults():
 
 
 def test_data_dir_becomes_path(tmp_path):
-    from lile.server import _parse_cli_args
+    from lile.cli import parse_cli_args as _parse_cli_args
 
     cfg = _parse_cli_args(["--data-dir", str(tmp_path)])
     assert cfg.data_dir == tmp_path
 
 
 def test_toggle_flags():
-    from lile.server import _parse_cli_args
+    from lile.cli import parse_cli_args as _parse_cli_args
 
     cfg = _parse_cli_args(["--no-4bit", "--idle-replay", "--frozen-ref"])
     assert cfg.load_in_4bit is False

--- a/lile/tests/test_server_cli.py
+++ b/lile/tests/test_server_cli.py
@@ -1,0 +1,56 @@
+"""CLI arg parsing for `python -m lile.server ...`.
+
+Pins the contract that Studio's /capsule/start subprocess.Popen relies on —
+specifically that ``--port`` and ``--model`` override the ServeConfig defaults.
+Before this fix, flags were silently ignored: the daemon always listened on
+the ServeConfig default port, so Studio's proxy (configured via ``LILE_PORT``)
+could never reach it.
+"""
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.cpu_only
+
+
+def test_defaults_match_serve_config():
+    from lile.config import ServeConfig
+    from lile.server import _parse_cli_args
+
+    default = ServeConfig()
+    cfg = _parse_cli_args([])
+    assert cfg.host == default.host
+    assert cfg.port == default.port
+    assert cfg.model == default.model
+    assert cfg.load_in_4bit is default.load_in_4bit
+
+
+def test_port_flag_overrides_default():
+    from lile.server import _parse_cli_args
+
+    cfg = _parse_cli_args(["--port", "8766"])
+    assert cfg.port == 8766
+
+
+def test_host_and_model_flags_override_defaults():
+    from lile.server import _parse_cli_args
+
+    cfg = _parse_cli_args(["--host", "0.0.0.0", "--model", "foo/bar"])
+    assert cfg.host == "0.0.0.0"
+    assert cfg.model == "foo/bar"
+
+
+def test_data_dir_becomes_path(tmp_path):
+    from lile.server import _parse_cli_args
+
+    cfg = _parse_cli_args(["--data-dir", str(tmp_path)])
+    assert cfg.data_dir == tmp_path
+
+
+def test_toggle_flags():
+    from lile.server import _parse_cli_args
+
+    cfg = _parse_cli_args(["--no-4bit", "--idle-replay", "--frozen-ref"])
+    assert cfg.load_in_4bit is False
+    assert cfg.idle_replay is True
+    assert cfg.frozen_ref is True


### PR DESCRIPTION
## Summary
Cherry-picks two clean commits from older open PRs that still apply against current `ht`.

- `c56b7231` (PR #21): `lile/server.py` now honors `--port`/`--host`/`--model` etc. Without this, `python -m lile.server --port X` silently falls back to `ServeConfig` defaults — which breaks Studio's `/capsule/start` (it spawns the daemon with `--port \$LILE_PORT`).
- `83a37fc2` (PR #31): metrics follow-ups from #20 review — `_seconds` suffix on histogram names, OpenMetrics negotiation, exemplar attachment, unmatched-route label collapsing.

Both PRs were marked CONFLICTING; rather than rebase 13+ stale commits, this picks the load-bearing commit from each.

## Test plan
- [x] `pytest lile/tests/test_server_cli.py lile/tests/test_metrics.py` → 19 passed
- [ ] After merge: confirm Studio `/capsule/start` health-check no longer 120s-timeouts on default-port mismatch
- [ ] After merge: close #21 and #31 with reference to this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)