### PR TITLE
studio: hybrid lile capsule — spawn-local OR connect-external

### DIFF
--- a/studio/backend/routes/lile.py
+++ b/studio/backend/routes/lile.py
@@ -1,26 +1,53 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""Lile capsule status + transparent proxy.
+"""Lile capsule lifecycle + transparent proxy.
 
-The lile daemon moved to heiervang-technologies/agi on 2026-05-15. Studio
-no longer spawns it; it just proxies HTTP traffic at LILE_DAEMON_URL.
+lile (the LiveLearn daemon) lives in heiervang-technologies/agi since
+2026-05-15. Studio talks to it in two modes:
+
+- **External**  — daemon is already running somewhere else; we just probe
+  ``LILE_DAEMON_URL`` (or legacy ``LILE_HOST`` + ``LILE_PORT``) and proxy.
+  Stop is a no-op.
+
+- **Spawned**   — if the ``lile`` package is importable in this Python
+  interpreter (install it via ``pip install lile @ git+...agi``), we can
+  start it as a subprocess and own its lifecycle. Stop sends SIGTERM.
+
+``capsule/start`` tries external first (cheap reachability probe), then
+falls back to spawn if available. ``capsule/status`` reports mode so the
+frontend can switch Load/Stop affordances.
 """
 
 from __future__ import annotations
 
+import asyncio
+import importlib.util
 import json
+import logging
 import os
+import signal
+import subprocess
+import sys
+import time
+from typing import Any
 
 import httpx
 from fastapi import APIRouter, Request
 from fastapi.responses import Response, StreamingResponse
 from pydantic import BaseModel
 
+log = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/lile", tags=["lile"])
 
+# Module-level state for the locally-spawned daemon, if any. ``None``
+# means we are in external-only mode (or have not yet spawned).
+_spawned: dict[str, Any] | None = None
 
+
+# ----------------------------------------------------------------- URL config
 def _lile_base_url() -> str:
+    """Resolve the daemon's base URL from env, preferring LILE_DAEMON_URL."""
     url = os.environ.get("LILE_DAEMON_URL")
     if url:
         return url.rstrip("/")
@@ -30,28 +57,136 @@ def _lile_base_url() -> str:
         return f"http://{host}:{port}"
     raise RuntimeError(
         "lile daemon location not configured: set LILE_DAEMON_URL "
-        "(or legacy LILE_HOST + LILE_PORT). lile lives in "
-        "heiervang-technologies/agi since 2026-05-15 and is no longer "
-        "spawnable from this process."
+        "(or legacy LILE_HOST + LILE_PORT). Install the package "
+        "(`pip install lile @ git+https://github.com/heiervang-technologies/agi`) "
+        "to spawn locally instead."
     )
 
 
+def _can_spawn() -> bool:
+    """Is the lile package importable in this Python interpreter?
+
+    Checked at call time (not import time) so the route module loads even
+    when lile isn't installed. Studio's optional extra
+    ``ht-unsloth-studio[lile]`` brings it in.
+    """
+    return importlib.util.find_spec("lile.console.launch") is not None
+
+
+def _spawn_port() -> int:
+    """Port for the spawned daemon. Reuses LILE_PORT when set, default 8768."""
+    raw = os.environ.get("LILE_PORT")
+    if raw:
+        try:
+            return int(raw)
+        except ValueError:
+            pass
+    return 8768
+
+
+async def _probe(base_url: str, timeout: float = 0.5) -> dict | None:
+    """Return /health JSON if reachable, else None."""
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as c:
+            r = await c.get(f"{base_url}/health")
+        if r.status_code == 200:
+            return r.json()
+    except httpx.HTTPError:
+        pass
+    return None
+
+
+# ----------------------------------------------------------------- spawn ops
+def _spawn_lile(req: "StartRequest") -> dict[str, Any]:
+    """Launch lile as a subprocess. Caller owns polling for readiness.
+
+    Returns ``{"pid", "port", "url", "log_path", "started_at"}``. Caller
+    sets ``_spawned`` to this dict once the daemon is health-probable so
+    /capsule/status can report mode=spawned.
+    """
+    if not _can_spawn():
+        raise RuntimeError(
+            "lile package not importable; pip install lile @ git+...agi "
+            "or set LILE_DAEMON_URL to point at a running daemon."
+        )
+    port = _spawn_port()
+    log_path = os.path.join(
+        os.environ.get("TMPDIR", "/tmp"), f"lile-spawn-{port}.log",
+    )
+    env = os.environ.copy()
+    env["LILE_HOST"] = "127.0.0.1"
+    env["LILE_PORT"] = str(port)
+    # Forward any caller-supplied overrides that launch.py honors via env.
+    for src, dst in (("model", "LILE_MODEL"),
+                     ("max_seq_length", "LILE_MAX_SEQ_LENGTH"),
+                     ("lora_rank", "LILE_LORA_RANK")):
+        v = getattr(req, src, None)
+        if v is not None:
+            env[dst] = str(v)
+    fh = open(log_path, "ab", buffering=0)
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "lile.console.launch"],
+        stdout=fh, stderr=subprocess.STDOUT, env=env,
+        start_new_session=True,  # keep child alive if Studio is restarted
+    )
+    return {
+        "pid": proc.pid,
+        "port": port,
+        "url": f"http://127.0.0.1:{port}",
+        "log_path": log_path,
+        "started_at": time.time(),
+    }
+
+
+async def _wait_for_health(base_url: str, deadline_s: float = 60.0) -> dict | None:
+    """Poll /health until 200 or deadline."""
+    t0 = time.time()
+    while time.time() - t0 < deadline_s:
+        health = await _probe(base_url, timeout=0.5)
+        if health:
+            return health
+        await asyncio.sleep(1.0)
+    return None
+
+
+def _is_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True  # process exists, just not ours — treat as alive
+
+
+# ----------------------------------------------------------------- routes
 @router.get("/capsule/status")
 async def capsule_status() -> dict:
-    url = f"{_lile_base_url()}/health"
+    global _spawned
+    # 1) we have a tracked subprocess — report that mode (regardless of env)
+    if _spawned and _is_alive(_spawned["pid"]):
+        health = await _probe(_spawned["url"])
+        if health:
+            return {"running": True, "mode": "spawned",
+                    "url": _spawned["url"], "pid": _spawned["pid"],
+                    "health": health}
+        return {"running": False, "mode": "spawned",
+                "url": _spawned["url"], "pid": _spawned["pid"],
+                "error": "subprocess alive but /health unreachable"}
+    # 2) tracked process died — clear it so a future start can re-spawn
+    if _spawned and not _is_alive(_spawned["pid"]):
+        log.info("lile spawned pid %s exited; clearing", _spawned["pid"])
+        _spawned = None
+    # 3) external mode
     try:
-        async with httpx.AsyncClient(timeout=0.5) as c:
-            r = await c.get(url)
-        if r.status_code != 200:
-            return {"running": False}
-        return {
-            "running": True,
-            "externally_managed": True,
-            "health": r.json(),
-            "url": _lile_base_url(),
-        }
-    except httpx.HTTPError:
-        return {"running": False}
+        base = _lile_base_url()
+    except RuntimeError as exc:
+        return {"running": False, "mode": "unconfigured", "error": str(exc)}
+    health = await _probe(base)
+    if health:
+        return {"running": True, "mode": "external",
+                "externally_managed": True, "url": base, "health": health}
+    return {"running": False, "mode": "external", "url": base}
 
 
 class StartRequest(BaseModel):
@@ -65,31 +200,88 @@ class StartRequest(BaseModel):
 
 @router.post("/capsule/start")
 async def capsule_start(req: StartRequest) -> dict:
-    # lile lives in heiervang-technologies/agi since 2026-05-15 and is no
-    # longer spawned by Studio. The endpoint stays so the frontend's
-    # capsule lifecycle UI keeps working; it now just reports whether the
-    # externally-managed daemon at LILE_DAEMON_URL is reachable.
-    del req  # all spawn-time parameters are configured on the daemon side
+    """Two-stage start: probe external URL first, fall back to subprocess spawn."""
+    global _spawned
+    # Stage 1: external daemon already serving?
     try:
-        async with httpx.AsyncClient(timeout=0.5) as c:
-            r = await c.get(f"{_lile_base_url()}/health")
-        if r.status_code == 200:
-            return {"running": True, "externally_managed": True,
-                    "health": r.json(), "url": _lile_base_url()}
-    except httpx.HTTPError:
-        pass
-    return {"running": False, "externally_managed": True,
-            "url": _lile_base_url(),
-            "error": "lile daemon not reachable at LILE_DAEMON_URL; start "
-                     "it from the agi repo (python -m lile.console.launch)"}
+        base = _lile_base_url()
+    except RuntimeError:
+        base = None
+    if base:
+        health = await _probe(base)
+        if health:
+            return {"running": True, "mode": "external",
+                    "externally_managed": True, "url": base, "health": health}
+
+    # Stage 2: we already spawned one — return its current state
+    if _spawned and _is_alive(_spawned["pid"]):
+        health = await _probe(_spawned["url"])
+        if health:
+            return {"running": True, "mode": "spawned",
+                    "url": _spawned["url"], "pid": _spawned["pid"],
+                    "health": health}
+
+    # Stage 3: try to spawn locally
+    if _can_spawn():
+        try:
+            info = _spawn_lile(req)
+        except Exception as exc:  # noqa: BLE001
+            log.exception("lile spawn failed")
+            return {"running": False, "mode": "spawn-failed", "error": str(exc)}
+        health = await _wait_for_health(info["url"], deadline_s=60.0)
+        if health:
+            _spawned = info
+            return {"running": True, "mode": "spawned",
+                    "url": info["url"], "pid": info["pid"],
+                    "health": health, "log_path": info["log_path"]}
+        # Spawned but never became healthy — record the PID so /stop can
+        # clean it up; tell the caller about the log file.
+        _spawned = info
+        return {"running": False, "mode": "spawned",
+                "url": info["url"], "pid": info["pid"],
+                "log_path": info["log_path"],
+                "error": "subprocess started but /health did not respond within 60s"}
+
+    # Stage 4: neither external reachable nor spawnable
+    return {"running": False,
+            "mode": "external-unreachable",
+            "url": base,
+            "error": "lile daemon not reachable at "
+                     f"{base or 'LILE_DAEMON_URL'} and the lile package "
+                     "is not installed (no spawn fallback)."
+                     " Install via `pip install lile @ git+...agi`"
+                     " or start the daemon externally."}
 
 
 @router.post("/capsule/stop")
 async def capsule_stop() -> dict:
-    # lile is externally managed since the move to heiervang-technologies/agi.
-    return {"stopped": False, "reason": "externally_managed"}
+    """Stop a spawned subprocess. No-op when externally managed."""
+    global _spawned
+    if not _spawned:
+        return {"stopped": False, "reason": "externally_managed"}
+    pid = _spawned["pid"]
+    if not _is_alive(pid):
+        _spawned = None
+        return {"stopped": True, "reason": "already_exited"}
+    try:
+        os.killpg(os.getpgid(pid), signal.SIGTERM)
+    except (ProcessLookupError, PermissionError) as exc:
+        log.warning("SIGTERM to lile pid %s failed: %s", pid, exc)
+    # Brief wait for graceful shutdown.
+    for _ in range(30):
+        if not _is_alive(pid):
+            break
+        await asyncio.sleep(0.5)
+    if _is_alive(pid):
+        try:
+            os.killpg(os.getpgid(pid), signal.SIGKILL)
+        except (ProcessLookupError, PermissionError):
+            pass
+    _spawned = None
+    return {"stopped": True, "reason": "subprocess_terminated", "pid": pid}
 
 
+# ---------------------------------------------------------------- proxy infra
 _HOP_BY_HOP = {"connection", "keep-alive", "proxy-authenticate",
                "proxy-authorization", "te", "trailers",
                "transfer-encoding", "upgrade", "host", "content-length"}
@@ -101,6 +293,17 @@ _PROXY_TIMEOUT = httpx.Timeout(connect=5.0, read=None, write=30.0, pool=5.0)
 
 def _forward_headers(headers) -> dict:
     return {k: v for k, v in headers.items() if k.lower() not in _HOP_BY_HOP}
+
+
+def _proxy_target_url() -> str:
+    """Where /api/lile/{path} forwards to.
+
+    Prefer the spawned subprocess (locally guaranteed; matches what we own),
+    fall back to the externally-configured URL.
+    """
+    if _spawned and _is_alive(_spawned["pid"]):
+        return _spawned["url"]
+    return _lile_base_url()
 
 
 async def _proxy_stream(method: str, url: str, headers: dict, body: bytes):
@@ -139,7 +342,7 @@ async def _proxy_stream(method: str, url: str, headers: dict, body: bytes):
     methods=["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
 )
 async def proxy(path: str, request: Request):
-    url = f"{_lile_base_url()}/{path}"
+    url = f"{_proxy_target_url()}/{path}"
     if request.url.query:
         url = f"{url}?{request.url.query}"
     body = await request.body()

--- a/studio/backend/routes/lile.py
+++ b/studio/backend/routes/lile.py
@@ -69,8 +69,16 @@ def _can_spawn() -> bool:
     Checked at call time (not import time) so the route module loads even
     when lile isn't installed. Studio's optional extra
     ``ht-unsloth-studio[lile]`` brings it in.
+
+    ``find_spec`` raises ``ModuleNotFoundError`` when a *parent* package is
+    missing (e.g. ``lile.console`` is asked for but ``lile.console`` itself
+    isn't a package). We treat that the same as "missing" — the module is
+    not importable in this interpreter.
     """
-    return importlib.util.find_spec("lile.console.launch") is not None
+    try:
+        return importlib.util.find_spec("lile.console.launch") is not None
+    except (ModuleNotFoundError, ValueError):
+        return False
 
 
 def _spawn_port() -> int:

--- a/studio/backend/tests/test_lile_route.py
+++ b/studio/backend/tests/test_lile_route.py
@@ -1,7 +1,12 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""Tests for the lile capsule lifecycle + proxy routes."""
+"""Tests for the lile capsule lifecycle + proxy routes.
+
+Two modes covered:
+- ``external`` — daemon is somewhere else; status/start probe ``LILE_DAEMON_URL``.
+- ``spawned``  — Studio spawned the daemon as a subprocess; stop SIGTERMs it.
+"""
 
 import json
 
@@ -16,19 +21,42 @@ def client():
     return TestClient(app)
 
 
+@pytest.fixture(autouse=True)
+def _clear_spawned_state():
+    """Reset module-level _spawned between tests so they don't bleed."""
+    from routes import lile as lile_mod
+    lile_mod._spawned = None
+    yield
+    lile_mod._spawned = None
+
+
+# ---------------------------------------------------------------- status
 def test_status_returns_offline_when_daemon_absent(client, monkeypatch):
-    """Status probe returns running:false when lile /health is unreachable."""
     monkeypatch.setenv("LILE_HOST", "127.0.0.1")
-    monkeypatch.setenv("LILE_PORT", "59999")  # nothing listening
+    monkeypatch.setenv("LILE_PORT", "59999")
+    monkeypatch.delenv("LILE_DAEMON_URL", raising=False)
     r = client.get("/api/lile/capsule/status")
     assert r.status_code == 200
-    assert r.json() == {"running": False}
+    body = r.json()
+    assert body["running"] is False
+    assert body["mode"] == "external"
+
+
+def test_status_unconfigured_when_no_env(client, monkeypatch):
+    monkeypatch.delenv("LILE_DAEMON_URL", raising=False)
+    monkeypatch.delenv("LILE_HOST", raising=False)
+    monkeypatch.delenv("LILE_PORT", raising=False)
+    r = client.get("/api/lile/capsule/status")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["running"] is False
+    assert body["mode"] == "unconfigured"
 
 
 def test_status_returns_health_when_daemon_reachable(client, monkeypatch, respx_mock):
-    """When lile /health responds 200, status mirrors the payload and url."""
     monkeypatch.setenv("LILE_HOST", "127.0.0.1")
     monkeypatch.setenv("LILE_PORT", "59999")
+    monkeypatch.delenv("LILE_DAEMON_URL", raising=False)
     body = {"ok": True, "model": "qwen3-0.6b", "queue_depth": 0,
             "commit_cursor": 7, "merges": 2}
     respx_mock.get("http://127.0.0.1:59999/health").respond(200, json=body)
@@ -36,42 +64,169 @@ def test_status_returns_health_when_daemon_reachable(client, monkeypatch, respx_
     assert r.status_code == 200
     payload = r.json()
     assert payload["running"] is True
+    assert payload["mode"] == "external"
+    assert payload["externally_managed"] is True
     assert payload["health"] == body
     assert payload["url"] == "http://127.0.0.1:59999"
-    assert payload["externally_managed"] is True
 
 
-def test_start_noop_when_already_running(client, monkeypatch, respx_mock):
+def test_status_reports_spawned_mode_when_subprocess_alive(client, monkeypatch, respx_mock):
+    """A tracked subprocess wins over env config in status reporting."""
+    from routes import lile as lile_mod
+    lile_mod._spawned = {"pid": 99999, "port": 59999,
+                         "url": "http://127.0.0.1:59999",
+                         "log_path": "/tmp/x", "started_at": 0}
+    monkeypatch.setattr(lile_mod, "_is_alive", lambda pid: True)
+    respx_mock.get("http://127.0.0.1:59999/health").respond(
+        200, json={"ok": True, "model": "qwen3"})
+    r = client.get("/api/lile/capsule/status")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["mode"] == "spawned"
+    assert body["pid"] == 99999
+    assert body["health"]["ok"] is True
+
+
+def test_status_clears_dead_subprocess(client, monkeypatch):
+    """If our tracked PID died, status clears it and falls through to external."""
+    from routes import lile as lile_mod
+    lile_mod._spawned = {"pid": 11111, "port": 59999,
+                         "url": "http://127.0.0.1:59999",
+                         "log_path": "/tmp/x", "started_at": 0}
+    monkeypatch.setattr(lile_mod, "_is_alive", lambda pid: False)
+    monkeypatch.setenv("LILE_HOST", "127.0.0.1")
+    monkeypatch.setenv("LILE_PORT", "59998")
+    monkeypatch.delenv("LILE_DAEMON_URL", raising=False)
+    r = client.get("/api/lile/capsule/status")
+    assert lile_mod._spawned is None
+    assert r.json()["mode"] == "external"
+
+
+# ---------------------------------------------------------------- start
+def test_start_noop_when_external_already_running(client, monkeypatch, respx_mock):
+    """External reachable => no spawn attempt; mode=external."""
     monkeypatch.setenv("LILE_HOST", "127.0.0.1")
     monkeypatch.setenv("LILE_PORT", "59999")
+    monkeypatch.delenv("LILE_DAEMON_URL", raising=False)
     respx_mock.get("http://127.0.0.1:59999/health").respond(200, json={"ok": True})
     r = client.post("/api/lile/capsule/start", json={})
     assert r.status_code == 200
     body = r.json()
     assert body["running"] is True
+    assert body["mode"] == "external"
     assert body["externally_managed"] is True
 
 
-def test_start_reports_unreachable_when_daemon_absent(client, monkeypatch):
-    """capsule/start no longer spawns; it just reports daemon reachability."""
+def test_start_falls_back_to_spawn_when_external_unreachable(client, monkeypatch):
+    """If external probe fails and lile is importable, spawn it."""
+    from routes import lile as lile_mod
+    monkeypatch.setenv("LILE_HOST", "127.0.0.1")
+    monkeypatch.setenv("LILE_PORT", "59996")  # nothing on this port
+    monkeypatch.delenv("LILE_DAEMON_URL", raising=False)
+    monkeypatch.setattr(lile_mod, "_can_spawn", lambda: True)
+
+    spawn_info = {"pid": 4242, "port": 59996,
+                  "url": "http://127.0.0.1:59996",
+                  "log_path": "/tmp/lile-spawn-59996.log",
+                  "started_at": 0}
+    monkeypatch.setattr(lile_mod, "_spawn_lile", lambda req: spawn_info)
+
+    async def _fake_wait(_url, deadline_s=60.0):  # noqa: ARG001
+        return {"ok": True, "model": "qwen3", "queue_depth": 0}
+    monkeypatch.setattr(lile_mod, "_wait_for_health", _fake_wait)
+
+    r = client.post("/api/lile/capsule/start", json={"model": "qwen3"})
+    body = r.json()
+    assert body["running"] is True
+    assert body["mode"] == "spawned"
+    assert body["pid"] == 4242
+    assert lile_mod._spawned == spawn_info
+
+
+def test_start_reports_unreachable_when_no_spawn_available(client, monkeypatch):
+    """Neither external nor spawnable => mode=external-unreachable with guidance."""
+    from routes import lile as lile_mod
     monkeypatch.setenv("LILE_DAEMON_URL", "http://127.0.0.1:59998")
+    monkeypatch.setattr(lile_mod, "_can_spawn", lambda: False)
     r = client.post("/api/lile/capsule/start", json={})
-    assert r.status_code == 200
     body = r.json()
     assert body["running"] is False
-    assert body["externally_managed"] is True
-    assert "LILE_DAEMON_URL" in body["error"]
+    assert body["mode"] == "external-unreachable"
+    assert "pip install lile" in body["error"]
 
 
-def test_stop_is_always_externally_managed(client):
-    """capsule/stop is a no-op since lile is externally managed."""
+def test_start_records_pid_even_when_health_times_out(client, monkeypatch):
+    """A spawn that doesn't become healthy still tracks the PID so /stop cleans up."""
+    from routes import lile as lile_mod
+    monkeypatch.setenv("LILE_HOST", "127.0.0.1")
+    monkeypatch.setenv("LILE_PORT", "59996")
+    monkeypatch.setattr(lile_mod, "_can_spawn", lambda: True)
+    info = {"pid": 5555, "port": 59996, "url": "http://127.0.0.1:59996",
+            "log_path": "/tmp/lile-spawn-59996.log", "started_at": 0}
+    monkeypatch.setattr(lile_mod, "_spawn_lile", lambda req: info)
+
+    async def _fake_wait(_url, deadline_s=60.0):  # noqa: ARG001
+        return None
+    monkeypatch.setattr(lile_mod, "_wait_for_health", _fake_wait)
+
+    r = client.post("/api/lile/capsule/start", json={})
+    body = r.json()
+    assert body["running"] is False
+    assert body["mode"] == "spawned"
+    assert body["pid"] == 5555
+    assert "did not respond" in body["error"]
+    assert lile_mod._spawned == info  # tracked for /stop
+
+
+# ---------------------------------------------------------------- stop
+def test_stop_is_noop_when_not_spawned(client):
     r = client.post("/api/lile/capsule/stop")
     assert r.status_code == 200
     assert r.json() == {"stopped": False, "reason": "externally_managed"}
 
 
+def test_stop_sigterms_tracked_subprocess(client, monkeypatch):
+    from routes import lile as lile_mod
+    lile_mod._spawned = {"pid": 7777, "port": 59999,
+                         "url": "http://127.0.0.1:59999",
+                         "log_path": "/tmp/x", "started_at": 0}
+    alive_calls = {"count": 0}
+    # First _is_alive call: yes; second (after SIGTERM loop): no.
+    def _alive(pid):
+        alive_calls["count"] += 1
+        return alive_calls["count"] <= 1
+    monkeypatch.setattr(lile_mod, "_is_alive", _alive)
+
+    killed: dict = {}
+    def _killpg(pgid, sig):
+        killed["pgid"] = pgid
+        killed["sig"] = sig
+    monkeypatch.setattr(lile_mod.os, "killpg", _killpg)
+    monkeypatch.setattr(lile_mod.os, "getpgid", lambda pid: pid)
+
+    r = client.post("/api/lile/capsule/stop")
+    body = r.json()
+    assert body["stopped"] is True
+    assert body["reason"] == "subprocess_terminated"
+    assert body["pid"] == 7777
+    assert killed["pgid"] == 7777
+    assert lile_mod._spawned is None
+
+
+def test_stop_handles_already_exited(client, monkeypatch):
+    from routes import lile as lile_mod
+    lile_mod._spawned = {"pid": 8888, "port": 59999,
+                         "url": "http://127.0.0.1:59999",
+                         "log_path": "/tmp/x", "started_at": 0}
+    monkeypatch.setattr(lile_mod, "_is_alive", lambda pid: False)
+    r = client.post("/api/lile/capsule/stop")
+    body = r.json()
+    assert body == {"stopped": True, "reason": "already_exited"}
+    assert lile_mod._spawned is None
+
+
+# ---------------------------------------------------------------- _lile_base_url
 def test_base_url_requires_configuration(monkeypatch):
-    """_lile_base_url raises if no env hints are set, surfacing the move."""
     from routes import lile as lile_mod
     monkeypatch.delenv("LILE_DAEMON_URL", raising=False)
     monkeypatch.delenv("LILE_HOST", raising=False)
@@ -88,9 +243,29 @@ def test_base_url_prefers_daemon_url_over_host_port(monkeypatch):
     assert lile_mod._lile_base_url() == "http://lile.example:8080"
 
 
+# ---------------------------------------------------------------- proxy
+def test_proxy_targets_spawned_when_alive(monkeypatch):
+    """Spawned subprocess wins over env URL for proxy target."""
+    from routes import lile as lile_mod
+    lile_mod._spawned = {"pid": 1234, "port": 59999,
+                         "url": "http://127.0.0.1:59999",
+                         "log_path": "/tmp/x", "started_at": 0}
+    monkeypatch.setattr(lile_mod, "_is_alive", lambda pid: True)
+    monkeypatch.setenv("LILE_DAEMON_URL", "http://external.example:8080")
+    assert lile_mod._proxy_target_url() == "http://127.0.0.1:59999"
+
+
+def test_proxy_falls_back_to_env_when_no_spawn(monkeypatch):
+    from routes import lile as lile_mod
+    lile_mod._spawned = None
+    monkeypatch.setenv("LILE_DAEMON_URL", "http://external.example:8080")
+    assert lile_mod._proxy_target_url() == "http://external.example:8080"
+
+
 def test_proxy_forwards_get(client, monkeypatch, respx_mock):
     monkeypatch.setenv("LILE_HOST", "127.0.0.1")
     monkeypatch.setenv("LILE_PORT", "59999")
+    monkeypatch.delenv("LILE_DAEMON_URL", raising=False)
     respx_mock.get("http://127.0.0.1:59999/v1/state/trajectory/tail")\
               .respond(200, json={"events": [], "next_offset": 0, "total_size": 0})
     r = client.get("/api/lile/v1/state/trajectory/tail")
@@ -101,6 +276,7 @@ def test_proxy_forwards_get(client, monkeypatch, respx_mock):
 def test_proxy_forwards_post_with_body(client, monkeypatch, respx_mock):
     monkeypatch.setenv("LILE_HOST", "127.0.0.1")
     monkeypatch.setenv("LILE_PORT", "59999")
+    monkeypatch.delenv("LILE_DAEMON_URL", raising=False)
     route = respx_mock.post("http://127.0.0.1:59999/v1/train")\
                       .respond(200, json={"queued": True})
     r = client.post("/api/lile/v1/train",
@@ -113,16 +289,17 @@ def test_proxy_forwards_post_with_body(client, monkeypatch, respx_mock):
 
 def test_proxy_502_on_upstream_down(client, monkeypatch):
     monkeypatch.setenv("LILE_HOST", "127.0.0.1")
-    monkeypatch.setenv("LILE_PORT", "59997")  # nothing listens
+    monkeypatch.setenv("LILE_PORT", "59997")
+    monkeypatch.delenv("LILE_DAEMON_URL", raising=False)
     r = client.get("/api/lile/v1/foo")
     assert r.status_code == 502
     assert "proxy upstream" in r.json()["error"]
 
 
 def test_proxy_forwards_head(client, monkeypatch, respx_mock):
-    """HEAD should be accepted by the proxy so health probes work."""
     monkeypatch.setenv("LILE_HOST", "127.0.0.1")
     monkeypatch.setenv("LILE_PORT", "59999")
+    monkeypatch.delenv("LILE_DAEMON_URL", raising=False)
     respx_mock.head("http://127.0.0.1:59999/healthz").respond(
         200, headers={"x-lile-probe": "ok"},
     )
@@ -132,7 +309,6 @@ def test_proxy_forwards_head(client, monkeypatch, respx_mock):
 
 
 def test_proxy_timeout_has_bounded_connect_unbounded_read():
-    """Regression guard: connect must fail fast, read must be None for SSE."""
     from routes import lile as lile_mod
     t = lile_mod._PROXY_TIMEOUT
     assert t.connect is not None and t.connect <= 10.0
@@ -142,6 +318,7 @@ def test_proxy_timeout_has_bounded_connect_unbounded_read():
 def test_proxy_streams_sse_without_buffering(client, monkeypatch, respx_mock):
     monkeypatch.setenv("LILE_HOST", "127.0.0.1")
     monkeypatch.setenv("LILE_PORT", "59999")
+    monkeypatch.delenv("LILE_DAEMON_URL", raising=False)
 
     sse_body = (b"data: {\"delta\": \"hel\"}\n\n"
                 b"data: {\"delta\": \"lo\"}\n\n"


### PR DESCRIPTION
## Summary
Restores the spawn path that #53 removed, while keeping the externally-managed contract. Studio's lile chat tab now works in both modes:

- **External**: if `LILE_DAEMON_URL` (or legacy `LILE_HOST`+`LILE_PORT`) points at a reachable daemon, use it. `mode="external"`, `externally_managed=true`. Stop is a no-op.
- **Spawned**: if external is unreachable and `lile` is importable in Studio's Python (install via `pip install lile @ git+https://github.com/heiervang-technologies/agi`), spawn `python -m lile.console.launch` as a subprocess. `mode="spawned"`, `pid` tracked. Stop SIGTERMs (then SIGKILL after 15s).

## Why
The user wanted UX preserved — *"unsloth studio should still spin up lile or connect to one"*. After the lile relocation (PR #52/#53/#54), spawn-local was lost. This brings it back as a fallback while keeping the new externally-managed mode the default.

## Behavior matrix
| External reachable | lile importable | Result |
|---|---|---|
| yes | — | `mode=external` (no spawn attempted) |
| no | yes | `mode=spawned` (subprocess + health-poll) |
| no | no | `mode=external-unreachable` (guidance error) |

`/api/lile/capsule/status` reports the active mode and clears dead PIDs. The transparent proxy now prefers the spawned URL over env config when a subprocess is alive — guarantees chat / train / state ops hit the daemon Studio owns.

## Test plan
- [x] `studio/backend/tests/test_lile_route.py`: 21 cases covering both modes, PID tracking on failed health-probe, stop SIGTERM, status clears dead PID, proxy target precedence. `_spawned` cleared between tests via autouse fixture. Syntax-checked locally; full pytest runs in CI.
- [ ] After merge: bump Studio's `pyproject.toml` to expose `pip install ht-unsloth-studio[lile]` extra pulling `lile @ git+...agi`. Optional follow-up — not in this PR since the spawn path also works for anyone with `lile` already on PYTHONPATH.
- [ ] Frontend: optionally surface `mode` in the capsule status pill (`Reachable` / `Spawned (pid)` / `Unreachable`). Cosmetic; not blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)