### PR TITLE
chore: gitignore lile leftovers post-relocation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,9 +218,11 @@ server.pid
 *.log
 package-lock.json
 
-# lile runtime state — per-process, not evidence.
-# bench_*.json files in lile_data/ are intentionally tracked (checked-in
-# reproducibility evidence for the §11 benchmark); the log + snapshots are
-# ephemeral. See PR#8 review.
-/lile_data/trajectory.jsonl
-/lile_data/snapshots/
+# lile relocated to heiervang-technologies/agi on 2026-05-15 (PR #52/#53).
+# These directories must not re-accumulate here — if you find yourself
+# generating files at these paths, you're in the wrong repo.
+/lile/
+/lile_data/
+
+# Playwright MCP cache — we don't use it (see CLAUDE.md memory).
+/.playwright-mcp/


### PR DESCRIPTION
## Summary
Replace the narrow lile_data ignores with full directory-level ignores now that lile/ is gone. Add .playwright-mcp/ since we don't use Playwright.

Catches a real failure mode: an agent or container running lile code in this checkout would silently re-create the directories. With this change they show up in `git status` as ignored noise rather than tracked candidates, so the next `git add -A` won't accidentally re-introduce stragglers.

## Test plan
- [x] Local `git status` clean (only .worktrees/ remains, which is a git worktree directory)
- [x] Pattern verified: creating a test file under lile/ or lile_data/ or .playwright-mcp/ does not show up in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)