### PR TITLE
feat(studio): surface lile capsule mode in status strip + load form

### DIFF
--- a/studio/frontend/src/features/lile/api/types.ts
+++ b/studio/frontend/src/features/lile/api/types.ts
@@ -9,10 +9,22 @@ export type HealthReport = {
   merges: number;
 };
 
+// Capsule mode (set by studio/backend/routes/lile.py:capsule_status):
+//   external      — daemon reachable at LILE_DAEMON_URL; we don't own its lifecycle
+//   spawned       — Studio launched the daemon as a subprocess; we own SIGTERM
+//   external-unreachable — env points somewhere but /health doesn't respond
+//   unconfigured  — no LILE_DAEMON_URL / LILE_HOST set
+export type CapsuleMode =
+  | "external"
+  | "spawned"
+  | "external-unreachable"
+  | "unconfigured";
+
 export type CapsuleStatus =
-  | { running: false }
-  | { running: true; externally_managed: boolean; health: HealthReport;
-      url: string };
+  | { running: false; mode?: CapsuleMode; url?: string; pid?: number;
+      error?: string }
+  | { running: true; mode?: CapsuleMode; externally_managed?: boolean;
+      health: HealthReport; url: string; pid?: number };
 
 export type TrainStepEvent = {
   offset: number;

--- a/studio/frontend/src/features/lile/components/capsule-load-form.tsx
+++ b/studio/frontend/src/features/lile/components/capsule-load-form.tsx
@@ -19,6 +19,11 @@ const MODEL_SUGGESTIONS = [
 export function CapsuleLoadForm(): ReactElement {
   const status = useLileCapsuleStore((s) => s.status);
   const running = status?.running === true;
+  // External-mode daemons are not Studio's lifecycle to own; Stop is a
+  // no-op on the backend (returns {stopped:false, reason:"externally_managed"}).
+  // Surface that to the user instead of letting them click and see nothing.
+  const mode = status?.mode;
+  const externalLifecycle = running && mode === "external";
 
   const [model, setModel] = useState("");
   const [maxSeqLength, setMaxSeqLength] = useState(2048);
@@ -69,10 +74,19 @@ export function CapsuleLoadForm(): ReactElement {
         <Button
           variant="destructive"
           onClick={handleStop}
-          disabled={submitting}
+          disabled={submitting || externalLifecycle}
+          title={externalLifecycle
+            ? "Daemon is externally managed — stop it from where it was launched"
+            : undefined}
         >
           {submitting ? "Stopping…" : "Stop capsule"}
         </Button>
+        {externalLifecycle && (
+          <p className="text-xs text-muted-foreground">
+            Daemon is externally managed at <code>{status?.url}</code>.
+            Stop it from the process that launched it.
+          </p>
+        )}
         {error && (
           <p className="text-sm text-destructive">{error}</p>
         )}

--- a/studio/frontend/src/features/lile/components/capsule-status-strip.test.tsx
+++ b/studio/frontend/src/features/lile/components/capsule-status-strip.test.tsx
@@ -35,4 +35,54 @@ describe("CapsuleStatusStrip", () => {
     expect(screen.getByText(/commit 77/)).toBeTruthy();
     expect(screen.getByText(/queue 3/)).toBeTruthy();
   });
+
+  it("shows spawned badge with pid when mode=spawned", () => {
+    useLileCapsuleStore.getState().setStatus({
+      running: true,
+      mode: "spawned",
+      pid: 4242,
+      health: {
+        ok: true, model: "qwen3-8b",
+        queue_depth: 0, commit_cursor: 0, merges: 0,
+      },
+      url: "http://127.0.0.1:8768",
+    });
+    render(<CapsuleStatusStrip />);
+    expect(screen.getByText(/spawned/)).toBeTruthy();
+    expect(screen.getByText(/pid 4242/)).toBeTruthy();
+  });
+
+  it("shows external badge when mode=external", () => {
+    useLileCapsuleStore.getState().setStatus({
+      running: true,
+      mode: "external",
+      health: {
+        ok: true, model: "qwen3-8b",
+        queue_depth: 0, commit_cursor: 0, merges: 0,
+      },
+      url: "http://remote.example:8768",
+    });
+    render(<CapsuleStatusStrip />);
+    expect(screen.getByText(/external/)).toBeTruthy();
+  });
+
+  it("explains unconfigured offline state", () => {
+    useLileCapsuleStore.getState().setStatus({
+      running: false,
+      mode: "unconfigured",
+    });
+    render(<CapsuleStatusStrip />);
+    expect(screen.getByText(/not configured/i)).toBeTruthy();
+    expect(screen.getByText(/LILE_DAEMON_URL/)).toBeTruthy();
+  });
+
+  it("surfaces unreachable-URL when external probe failed", () => {
+    useLileCapsuleStore.getState().setStatus({
+      running: false,
+      mode: "external-unreachable",
+      url: "http://remote.example:8768",
+    });
+    render(<CapsuleStatusStrip />);
+    expect(screen.getByText(/not reachable at http:\/\/remote\.example:8768/)).toBeTruthy();
+  });
 });

--- a/studio/frontend/src/features/lile/components/capsule-status-strip.tsx
+++ b/studio/frontend/src/features/lile/components/capsule-status-strip.tsx
@@ -7,14 +7,24 @@ import { useLileCapsuleStore } from "../stores/lile-capsule-store";
 export function CapsuleStatusStrip() {
   const status = useLileCapsuleStore((s) => s.status);
   if (!status || !status.running) {
+    const mode = status?.mode;
+    const label = mode === "unconfigured"
+      ? "Lile not configured (set LILE_DAEMON_URL)"
+      : mode === "external-unreachable"
+      ? `Lile not reachable at ${status?.url ?? "configured URL"}`
+      : "Lile daemon not reachable";
     return (
       <div className="flex items-center gap-2 text-sm text-muted-foreground">
         <Badge variant="secondary">offline</Badge>
-        <span>Lile daemon not reachable</span>
+        <span>{label}</span>
       </div>
     );
   }
   const h = status.health;
+  // Prefer the new `mode` field; fall back to legacy `externally_managed`
+  // for any client that hasn't refreshed since the spawn-or-connect rework.
+  const mode = status.mode
+    ?? (status.externally_managed ? "external" : undefined);
   return (
     <div className="flex items-center gap-4 text-sm">
       <Badge variant="default">online</Badge>
@@ -22,7 +32,12 @@ export function CapsuleStatusStrip() {
       <span>queue {h.queue_depth}</span>
       <span>commit {h.commit_cursor}</span>
       <span>merges {h.merges}</span>
-      {status.externally_managed && <Badge variant="outline">external</Badge>}
+      {mode === "external" && <Badge variant="outline">external</Badge>}
+      {mode === "spawned" && (
+        <Badge variant="outline">
+          spawned{status.pid ? ` (pid ${status.pid})` : ""}
+        </Badge>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Frontend follow-up to PR #55 (hybrid capsule). The backend started reporting a richer \`mode: external|spawned|external-unreachable|unconfigured\` field on \`/api/lile/capsule/status\`; this PR teaches the UI to read it.

- **CapsuleStatus** type gains \`mode?: CapsuleMode\` on both arms; legacy \`externally_managed\` kept for forward-compat with old daemons.
- **Status strip** now renders \"external\" or \"spawned (pid N)\" badges per mode, and differentiates offline reasons (\`unconfigured\` → guidance; \`external-unreachable\` → which URL failed; bare → generic).
- **Load form** disables Stop when \`mode === \"external\"\` because the backend no-ops in that mode. Adds a one-line explanation pointing users at the launching process.

## Test plan
- [x] \`bun test capsule-status-strip.test.tsx\` → 6 pass (4 new mode cases + 2 originals)
- [x] \`npx tsc --noEmit\` clean
- [ ] Manual: when daemon runs externally, Stop button shows disabled with tooltip; when daemon is Studio-spawned, Stop is enabled and works

🤖 Generated with [Claude Code](https://claude.com/claude-code)