### PR TITLE
fix(frontend): sync missing store properties and fix build errors from upstream rebase

### DIFF
--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -716,9 +716,9 @@ const CopyButton: FC = () => {
   const [copied, setCopied] = useState(false);
   const resetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const handleCopy = () => {
+  const handleCopy = async () => {
     const text = aui.message().getCopyText();
-    if (copyToClipboard(text)) {
+    if (await copyToClipboard(text)) {
       setCopied(true);
       if (resetTimeoutRef.current) clearTimeout(resetTimeoutRef.current);
       resetTimeoutRef.current = setTimeout(() => {

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -58,7 +58,8 @@ import {
   Trash2Icon,
   XIcon,
 } from "lucide-react";
-import { type FC, useCallback, useEffect, useRef, useState } from "react";
+import { type FC, useCallback, useEffect, useRef, useState, type ChangeEvent, type KeyboardEvent, type CompositionEvent, type FormEvent } from "react";
+import { flushResourcesSync } from "@assistant-ui/tap";
 import { toast } from "sonner";
 import { deleteThreadMessage } from "@/features/chat/utils/delete-thread-message";
 import { useChatRuntimeStore } from "@/features/chat/stores/chat-runtime-store";
@@ -302,9 +303,138 @@ const PendingAudioChip: FC = () => {
   );
 };
 
-const Composer: FC = () => {
+function isNativeComposing(event: Event) {
+  return "isComposing" in event && (event as Event & { isComposing?: boolean }).isComposing === true;
+}
+
+const IME_STUCK_TIMEOUT_MS = 2500;
+
+function useImeComposerInputHandlers() {
+  const aui = useAui();
+  const composingRef = useRef(false);
+  const [isComposing, setIsComposing] = useState(false);
+  const stuckTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearStuckTimer = useCallback(() => {
+    if (stuckTimerRef.current) {
+      clearTimeout(stuckTimerRef.current);
+      stuckTimerRef.current = null;
+    }
+  }, []);
+
+  const setCompositionState = useCallback(
+    (next: boolean) => {
+      composingRef.current = next;
+      setIsComposing(next);
+      clearStuckTimer();
+      if (next) {
+        stuckTimerRef.current = setTimeout(() => {
+          stuckTimerRef.current = null;
+          composingRef.current = false;
+          setIsComposing(false);
+        }, IME_STUCK_TIMEOUT_MS);
+      }
+    },
+    [clearStuckTimer],
+  );
+
+  const refreshStuckTimer = useCallback(() => {
+    if (!composingRef.current) {
+      return;
+    }
+    clearStuckTimer();
+    stuckTimerRef.current = setTimeout(() => {
+      stuckTimerRef.current = null;
+      composingRef.current = false;
+      setIsComposing(false);
+    }, IME_STUCK_TIMEOUT_MS);
+  }, [clearStuckTimer]);
+
+  useEffect(() => clearStuckTimer, [clearStuckTimer]);
+
+  const setComposerText = useCallback(
+    (value: string) => {
+      const composer = aui.composer();
+      if (!composer.getState().isEditing) {
+        return;
+      }
+      flushResourcesSync(() => {
+        composer.setText(value);
+      });
+    },
+    [aui],
+  );
+
+  const onCompositionStart = useCallback(() => {
+    setCompositionState(true);
+  }, [setCompositionState]);
+
+  const onCompositionUpdate = useCallback(() => {
+    refreshStuckTimer();
+  }, [refreshStuckTimer]);
+
+  const onCompositionEnd = useCallback(
+    (e: CompositionEvent<HTMLTextAreaElement>) => {
+      setCompositionState(false);
+      setComposerText(e.currentTarget.value);
+    },
+    [setComposerText, setCompositionState],
+  );
+
+  const onChange = useCallback(
+    (e: ChangeEvent<HTMLTextAreaElement>) => {
+      setCompositionState(isNativeComposing(e.nativeEvent));
+      setComposerText(e.target.value);
+    },
+    [setComposerText, setCompositionState],
+  );
+
+  const onKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.nativeEvent.isComposing || e.keyCode === 229) {
+        composingRef.current = true;
+        refreshStuckTimer();
+      }
+    },
+    [refreshStuckTimer],
+  );
+
+  return {
+    inputProps: {
+      onCompositionStart,
+      onCompositionUpdate,
+      onCompositionEnd,
+      onChange,
+      onKeyDown,
+    },
+    isComposing,
+    isComposingRef: composingRef,
+  };
+}
+
+const Composer: FC<{ disabled?: boolean }> = ({ disabled }) => {
+  const { inputProps, isComposing, isComposingRef } = useImeComposerInputHandlers();
+  const hasPendingAttachments = useAuiState(({ composer }) =>
+    composer.attachments.some(
+      (attachment) => attachment.status.type === "running",
+    ),
+  );
+
+  const handleSubmit = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      if (disabled || isComposingRef.current || hasPendingAttachments) {
+        event.preventDefault();
+      }
+    },
+    [disabled, hasPendingAttachments, isComposingRef],
+  );
+
   return (
-    <ComposerPrimitive.Root className="aui-composer-root relative flex w-full flex-col">
+    <ComposerPrimitive.Root
+      className="aui-composer-root relative flex w-full flex-col"
+      aria-disabled={disabled}
+      onSubmit={handleSubmit}
+    >
       <ComposerPrimitive.AttachmentDropzone className="aui-composer-attachment-dropzone chat-composer-surface flex w-full flex-col rounded-3xl bg-background px-1 pt-2 outline-none transition-shadow data-[dragging=true]:border-ring data-[dragging=true]:bg-accent/50">
         <ComposerAttachments />
         <PendingAudioChip />
@@ -314,10 +444,16 @@ const Composer: FC = () => {
           className="aui-composer-input mb-1 min-h-12 w-full resize-none overflow-y-auto bg-transparent pl-5 pr-4 pt-2 pb-3 text-sm outline-none placeholder:text-muted-foreground focus-visible:ring-0"
           minRows={1}
           maxRows={6}
-          autoFocus={true}
+          autoFocus={!disabled}
+          disabled={disabled}
           aria-label="Message input"
+          dir="auto"
+          {...inputProps}
         />
-        <ComposerAction />
+        <ComposerAction
+          disabled={disabled || isComposing || hasPendingAttachments}
+          blockSend={() => isComposingRef.current || hasPendingAttachments}
+        />
       </ComposerPrimitive.AttachmentDropzone>
     </ComposerPrimitive.Root>
   );
@@ -552,7 +688,10 @@ const ToolStatusDisplay: FC = () => {
   );
 };
 
-const ComposerAction: FC = () => {
+const ComposerAction: FC<{ disabled?: boolean; blockSend?: () => boolean }> = ({
+  disabled,
+  blockSend,
+}) => {
   return (
     <div className="aui-composer-action-wrapper relative mx-2 mb-2 flex items-center justify-between">
       <div className="flex items-center gap-1">
@@ -593,6 +732,12 @@ const ComposerAction: FC = () => {
               type="submit"
               variant="default"
               size="icon"
+              disabled={disabled}
+              onClick={(event) => {
+                if (blockSend?.()) {
+                  event.preventDefault();
+                }
+              }}
               className="aui-composer-send size-8 rounded-full"
               aria-label="Send message"
             >
@@ -869,6 +1014,7 @@ const UserActionBar: FC = () => {
 
 const EditComposer: FC = () => {
   const aui = useAui();
+  const { inputProps, isComposingRef } = useImeComposerInputHandlers();
   const resendAfterCancelRef = useRef(false);
 
   useAuiEvent("thread.runEnd", () => {
@@ -885,16 +1031,23 @@ const EditComposer: FC = () => {
         <ComposerPrimitive.Input
           className="aui-edit-composer-input min-h-14 w-full resize-none bg-transparent p-4 text-foreground text-sm outline-none"
           autoFocus={true}
+          dir="auto"
+          {...inputProps}
         />
         <div className="aui-edit-composer-footer mx-3 mb-3 flex items-center gap-2 self-end">
           <ComposerPrimitive.Cancel asChild={true}>
-            <Button variant="ghost" size="sm">
+            <Button type="button" variant="ghost" size="sm">
               Cancel
             </Button>
           </ComposerPrimitive.Cancel>
           <Button
+            type="button"
             size="sm"
-            onClick={() => {
+            onClick={(event) => {
+              if (isComposingRef.current) {
+                event.preventDefault();
+                return;
+              }
               const newText = aui.composer().getState().text;
               const originalText = aui.message().getCopyText();
 

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -21,6 +21,7 @@ import {
   hasClosedThinkTag,
   parseAssistantContent,
 } from "../utils/parse-assistant-content";
+import { getAuthToken } from "@/features/auth/session";
 
 /** Server-side usage data from llama-server (via stream_options.include_usage). */
 interface ServerUsage {
@@ -535,6 +536,21 @@ async function autoLoadSmallestModel(): Promise<{
 export function createOpenAIStreamAdapter(): ChatModelAdapter {
   return {
     async *run({ messages, abortSignal, unstable_threadId }) {
+      const cancelId = crypto.randomUUID?.() || Math.random().toString(36).slice(2);
+      const onAbortCancel = () => {
+        const token = getAuthToken();
+        fetch("/api/inference/cancel", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          },
+          body: JSON.stringify({ cancel_id: cancelId }),
+          keepalive: true,
+        }).catch(console.error);
+      };
+      abortSignal.addEventListener("abort", onAbortCancel);
+
       let runtime = useChatRuntimeStore.getState();
       // Capture the thread ID once at the start so it stays stable even if
       // the user switches chats while waiting for model load / auto-load.
@@ -720,6 +736,7 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
             presence_penalty: params.presencePenalty,
             image_base64: imageBase64,
             audio_base64: audioBase64,
+            cancel_id: cancelId,
             ...(useAdapter === undefined ? {} : { use_adapter: useAdapter }),
             ...(supportsReasoning ? { enable_thinking: reasoningEnabled } : {}),
             ...(supportsTools && (toolsEnabled || codeToolsEnabled)
@@ -978,6 +995,7 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
           }
         }
         runtime.setThreadRunning(threadKey, false);
+        abortSignal.removeEventListener("abort", onAbortCancel);
       }
     },
   };

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -164,7 +164,7 @@ const SingleContent = memo(function SingleContent({
       newThreadNonce={newThreadNonce}
     >
       <div className="flex min-h-0 min-w-0 flex-1 basis-0 flex-col overflow-hidden">
-        <Thread hideWelcome={Boolean(threadId)} targetThreadId={threadId} />
+        <Thread hideWelcome={Boolean(threadId)} />
       </div>
     </ChatRuntimeProvider>
   );
@@ -1615,17 +1615,6 @@ export function ChatPage(): ReactElement {
         onOpenChange={setSettingsOpen}
         params={inferenceParams}
         onParamsChange={setInferenceParams}
-        isExternalModel={isExternalModel}
-        providerCapabilities={activeProviderCapabilities}
-        activeExternalProvider={activeExternalProvider}
-        onExternalProviderChange={(updatedProvider) => {
-          setExternalProviders(
-            externalProviders.map((provider) =>
-              provider.id === updatedProvider.id ? updatedProvider : provider,
-            ),
-          );
-        }}
-        externalProviderType={activeExternalProviderType}
         onReloadModel={() => {
           const state = useChatRuntimeStore.getState();
           if (state.params.checkpoint) {

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -58,6 +58,14 @@ import {
   SlidersHorizontalIcon,
   Wrench01Icon,
 } from "@hugeicons/core-free-icons";
+
+export function InfoHint({ children }: { children: React.ReactNode }) {
+  return (
+    <div title={typeof children === "string" ? children : "Info"}>
+      <HugeiconsIcon icon={AiBrain01Icon} className="h-4 w-4 text-muted-foreground opacity-50" />
+    </div>
+  );
+}
 import { HugeiconsIcon } from "@hugeicons/react";
 import { AnimatePresence, motion } from "motion/react";
 import type { ReactNode } from "react";

--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -1,23 +1,187 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+import { toast } from "@/lib/toast";
 import { create } from "zustand";
-import { toast } from "sonner";
+import {
+  type ChatPresetSource,
+  type Preset,
+  getPresetSource,
+} from "../presets/preset-policy";
+import {
+  type ChatLoraSummary,
+  type ChatModelSummary,
+  DEFAULT_INFERENCE_PARAMS,
+  type InferenceParams,
+} from "../types/runtime";
+import { isExternalModelId, parseExternalModelId } from "../external-providers";
+import { getExternalMaxOutputTokens } from "../provider-capabilities";
+import { useExternalProvidersStore } from "./external-providers-store";
+import {
+  loadChatSettingsWithLegacyImport,
+  savePersistedChatSettingsPatch,
+} from "../utils/chat-settings-storage";
 
-// Upstream-compat shim: localStorage keys + helpers that upstream's
-// chat-page.tsx imports from this module. HT's chat-runtime-store
-// pre-dates these additions; expose them to satisfy the imports.
-// Eventually HT's store should adopt the upstream key/setter convention
-// for tool toggles; until then, these are inert getters for compat only.
+const HF_TOKEN_KEY = "unsloth_hf_token";
+const LILE_MODE_KEY = "unsloth_lile_mode";
+const LILE_BLOCK_KEY = "unsloth_lile_block_on_last_commit";
 export const CHAT_REASONING_ENABLED_KEY = "unsloth_chat_reasoning_enabled";
 export const CHAT_TOOLS_ENABLED_KEY = "unsloth_chat_tools_enabled";
 export const CHAT_CODE_TOOLS_ENABLED_KEY = "unsloth_chat_code_tools_enabled";
 export const CHAT_IMAGE_TOOLS_ENABLED_KEY = "unsloth_chat_image_tools_enabled";
+export const CHAT_ARTIFACTS_ENABLED_KEY = "unsloth_chat_artifacts_enabled";
+export const CHAT_COLLAPSE_HTML_ARTIFACTS_KEY =
+  "unsloth_chat_collapse_html_artifacts";
+export const CHAT_ALLOW_ARTIFACT_NETWORK_ACCESS_KEY =
+  "unsloth_chat_allow_artifact_network_access";
+export const CHAT_MCP_ENABLED_KEY = "unsloth_chat_mcp_enabled";
 export const CHAT_WEB_FETCH_TOOLS_ENABLED_KEY =
   "unsloth_chat_web_fetch_tools_enabled";
 
+// External provider selection is encoded into `params.checkpoint` as
+// `external::<providerId>::<modelId>`. PersistedChatSettings deliberately
+// Omits `checkpoint` because the local-model side is mirrored by the
+// backend's `/api/inference/status.active_model` response. External
+// selections have no such backend mirror, so without explicit
+// localStorage persistence here the user's external pick is silently
+// reset to the default on every page refresh.
+const LAST_EXTERNAL_CHECKPOINT_KEY = "unsloth_chat_last_external_checkpoint";
+
+function loadLastExternalCheckpoint(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const value = window.localStorage.getItem(LAST_EXTERNAL_CHECKPOINT_KEY);
+    return isExternalModelId(value) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+function saveLastExternalCheckpoint(value: string | null): void {
+  if (typeof window === "undefined") return;
+  try {
+    if (value && isExternalModelId(value)) {
+      window.localStorage.setItem(LAST_EXTERNAL_CHECKPOINT_KEY, value);
+    } else {
+      // Clearing on a switch to a local / empty checkpoint means the
+      // next refresh won't override the now-active local selection.
+      window.localStorage.removeItem(LAST_EXTERNAL_CHECKPOINT_KEY);
+    }
+  } catch {
+    // Storage quota / private-mode failures are non-fatal -- the
+    // selection just won't survive the refresh.
+  }
+}
+
+export type ReasoningStyle = "enable_thinking" | "reasoning_effort";
+export type PendingImageEditReference = {
+  threadId: string | null;
+  openaiImageGenerationCallId: string;
+  openaiResponseId?: string;
+  openaiReasoningItem?: unknown;
+};
+export type ReasoningEffort =
+  | "none"
+  | "minimal"
+  | "low"
+  | "medium"
+  | "high"
+  | "max"
+  | "xhigh";
+
+let hasShownSettingsPersistenceWarning = false;
+let customPresetsMutationVersion = 0;
+let activePresetMutationVersion = 0;
+let activePresetSourceMutationVersion = 0;
+let settingsHydrationPromise: Promise<void> | null = null;
+
+function warnSettingsPersistenceFailure(): void {
+  if (hasShownSettingsPersistenceWarning) {
+    return;
+  }
+  hasShownSettingsPersistenceWarning = true;
+  toast.warning("Chat settings could not be persisted", {
+    description: "Your changes apply now, but may reset after refresh.",
+  });
+}
+
+// Coalesce setting writes into one pendingPatch (deep merge for nested
+// keys), flush on a trailing-edge debounce, flush on beforeunload so a
+// pending patch survives tab close. Slider drag ticks now produce one
+// HTTP write per quiet window instead of one per tick.
+type SettingsPatch = Parameters<typeof savePersistedChatSettingsPatch>[0];
+
+const SETTINGS_DEBOUNCE_MS = 400;
+let pendingPatch: SettingsPatch = {};
+let pendingTimer: ReturnType<typeof setTimeout> | null = null;
+let inflightFlush: Promise<void> = Promise.resolve();
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function mergePatch(into: SettingsPatch, more: SettingsPatch): void {
+  for (const [key, value] of Object.entries(more)) {
+    const intoAny = into as Record<string, unknown>;
+    const prev = intoAny[key];
+    if (isPlainObject(prev) && isPlainObject(value)) {
+      intoAny[key] = { ...prev, ...value };
+    } else {
+      intoAny[key] = value;
+    }
+  }
+}
+
+async function flushSettingsPatch(keepalive = false): Promise<void> {
+  if (Object.keys(pendingPatch).length === 0) return;
+  const patch = pendingPatch;
+  pendingPatch = {};
+  try {
+    await savePersistedChatSettingsPatch(patch, { keepalive });
+  } catch {
+    const retryPatch: SettingsPatch = {};
+    mergePatch(retryPatch, patch);
+    mergePatch(retryPatch, pendingPatch);
+    pendingPatch = retryPatch;
+    warnSettingsPersistenceFailure();
+  }
+}
+
+function saveSettingsPatch(patch: SettingsPatch): void {
+  mergePatch(pendingPatch, patch);
+  if (pendingTimer !== null) clearTimeout(pendingTimer);
+  pendingTimer = setTimeout(() => {
+    pendingTimer = null;
+    inflightFlush = inflightFlush
+      .catch(() => undefined)
+      .then(() => flushSettingsPatch());
+  }, SETTINGS_DEBOUNCE_MS);
+}
+
+// Best-effort flush of any pending patch when the tab closes. keepalive
+// lets the PUT outlive the unload; without it the browser cancels the
+// fetch and the user's last slider drag is dropped.
+if (typeof window !== "undefined") {
+  window.addEventListener("beforeunload", () => {
+    if (pendingTimer !== null) clearTimeout(pendingTimer);
+    if (Object.keys(pendingPatch).length === 0) return;
+    inflightFlush = inflightFlush
+      .catch(() => undefined)
+      .then(() => flushSettingsPatch(true));
+  });
+}
+
+function canUseStorage(): boolean {
+  return typeof window !== "undefined";
+}
+
+function loadBool(key: string, fallback: boolean): boolean {
+  const raw = loadOptionalBool(key);
+  return raw ?? fallback;
+}
+
 export function loadOptionalBool(key: string): boolean | null {
-  if (typeof localStorage === "undefined") return null;
+  if (!canUseStorage()) return null;
   try {
     const raw = localStorage.getItem(key);
     if (raw === null) return null;
@@ -27,6 +191,12 @@ export function loadOptionalBool(key: string): boolean | null {
   }
 }
 
+/**
+ * Resolve the web-search / code-execution pill state to apply when a model
+ * loads. Honors the user's persisted preference so loading a tool-capable
+ * model never silently re-enables a pill the user turned off; falls back to
+ * the model's capability only when no preference has been expressed.
+ */
 export function resolveToolsEnabledOnLoad(supportsTools: boolean): {
   toolsEnabled: boolean;
   codeToolsEnabled: boolean;
@@ -37,63 +207,11 @@ export function resolveToolsEnabledOnLoad(supportsTools: boolean): {
     codeToolsEnabled: loadOptionalBool(CHAT_CODE_TOOLS_ENABLED_KEY) ?? true,
   };
 }
-import {
-  DEFAULT_INFERENCE_PARAMS,
-  type ChatLoraSummary,
-  type ChatModelSummary,
-  type InferenceParams,
-} from "../types/runtime";
-
-const AUTO_TITLE_KEY = "unsloth_chat_auto_title";
-const AUTO_HEAL_TOOL_CALLS_KEY = "unsloth_auto_heal_tool_calls";
-const MAX_TOOL_CALLS_KEY = "unsloth_max_tool_calls_per_message";
-const TOOL_CALL_TIMEOUT_KEY = "unsloth_tool_call_timeout";
-const HF_TOKEN_KEY = "unsloth_hf_token";
-const INFERENCE_PARAMS_KEY = "unsloth_chat_inference_params";
-const LILE_MODE_KEY = "unsloth_lile_mode";
-const LILE_BLOCK_KEY = "unsloth_lile_block_on_last_commit";
-let hasShownInferencePersistenceWarning = false;
-
-function canUseStorage(): boolean {
-  return typeof window !== "undefined";
-}
-
-function loadBool(key: string, fallback: boolean): boolean {
-  if (!canUseStorage()) return fallback;
-  try {
-    const raw = localStorage.getItem(key);
-    if (raw === null) return fallback;
-    return raw === "true";
-  } catch {
-    return fallback;
-  }
-}
 
 function saveBool(key: string, value: boolean): void {
   if (!canUseStorage()) return;
   try {
     localStorage.setItem(key, value ? "true" : "false");
-  } catch {
-    // ignore
-  }
-}
-
-function loadInt(key: string, fallback: number): number {
-  if (!canUseStorage()) return fallback;
-  try {
-    const raw = localStorage.getItem(key);
-    if (raw === null) return fallback;
-    const parsed = parseInt(raw, 10);
-    return Number.isNaN(parsed) ? fallback : parsed;
-  } catch {
-    return fallback;
-  }
-}
-
-function saveInt(key: string, value: number): void {
-  if (!canUseStorage()) return;
-  try {
-    localStorage.setItem(key, String(value));
   } catch {
     // ignore
   }
@@ -117,71 +235,16 @@ function saveString(key: string, value: string): void {
   }
 }
 
-function asFiniteNumber(value: unknown, fallback: number): number {
-  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
-}
-
-function asString(value: unknown, fallback: string): string {
-  return typeof value === "string" ? value : fallback;
-}
-
-function asBoolean(value: unknown, fallback: boolean): boolean {
-  return typeof value === "boolean" ? value : fallback;
-}
-
-function loadInferenceParams(): InferenceParams {
-  if (!canUseStorage()) return DEFAULT_INFERENCE_PARAMS;
-  try {
-    const raw = localStorage.getItem(INFERENCE_PARAMS_KEY);
-    if (!raw) return DEFAULT_INFERENCE_PARAMS;
-    const parsed = JSON.parse(raw) as Partial<InferenceParams>;
-    return {
-      temperature: asFiniteNumber(parsed.temperature, DEFAULT_INFERENCE_PARAMS.temperature),
-      topP: asFiniteNumber(parsed.topP, DEFAULT_INFERENCE_PARAMS.topP),
-      topK: asFiniteNumber(parsed.topK, DEFAULT_INFERENCE_PARAMS.topK),
-      minP: asFiniteNumber(parsed.minP, DEFAULT_INFERENCE_PARAMS.minP),
-      repetitionPenalty: asFiniteNumber(
-        parsed.repetitionPenalty,
-        DEFAULT_INFERENCE_PARAMS.repetitionPenalty,
-      ),
-      presencePenalty: asFiniteNumber(
-        parsed.presencePenalty,
-        DEFAULT_INFERENCE_PARAMS.presencePenalty,
-      ),
-      maxSeqLength: asFiniteNumber(
-        parsed.maxSeqLength,
-        DEFAULT_INFERENCE_PARAMS.maxSeqLength,
-      ),
-      maxTokens: asFiniteNumber(parsed.maxTokens, DEFAULT_INFERENCE_PARAMS.maxTokens),
-      systemPrompt: asString(parsed.systemPrompt, DEFAULT_INFERENCE_PARAMS.systemPrompt),
-      checkpoint: DEFAULT_INFERENCE_PARAMS.checkpoint,
-      trustRemoteCode: asBoolean(
-        parsed.trustRemoteCode,
-        DEFAULT_INFERENCE_PARAMS.trustRemoteCode ?? false,
-      ),
-    };
-  } catch {
-    return DEFAULT_INFERENCE_PARAMS;
-  }
-}
-
-function saveInferenceParams(params: InferenceParams): boolean {
-  if (!canUseStorage()) return false;
-  try {
-    const { checkpoint, ...rest } = params;
-    void checkpoint;
-    localStorage.setItem(INFERENCE_PARAMS_KEY, JSON.stringify(rest));
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 type ChatRuntimeStore = {
+  settingsHydrated: boolean;
   params: InferenceParams;
+  customPresets: Preset[];
+  activePreset: string;
+  activePresetSource: ChatPresetSource;
   models: ChatModelSummary[];
   loras: ChatLoraSummary[];
   runningByThreadId: Record<string, boolean>;
+  cancelByThreadId: Record<string, () => void>;
   autoTitle: boolean;
   hfToken: string;
   modelsError: string | null;
@@ -193,9 +256,66 @@ type ChatRuntimeStore = {
   supportsReasoning: boolean;
   reasoningAlwaysOn: boolean;
   reasoningEnabled: boolean;
+  /**
+   * The model id the OpenRouter router actually picked for the most recent
+   * stream when the active checkpoint is the openrouter/free meta-model.
+   * Updated each time a chunk arrives carrying a non-empty `model` field
+   * that differs from the requested id. Cleared when a non-OpenRouter
+   * model is selected. Used purely for UI display — appended after
+   * `openrouter/free:` in the active model chip.
+   */
+  lastOpenRouterChosenModel: string | null;
+  reasoningStyle: ReasoningStyle;
+  reasoningEffort: ReasoningEffort;
+  supportsReasoningOff: boolean;
+  reasoningEffortLevels: readonly ReasoningEffort[];
+  supportsPreserveThinking: boolean;
+  preserveThinking: boolean;
   supportsTools: boolean;
+  /**
+   * Whether the active external provider exposes a server-side
+   * web_search tool (OpenAI's /v1/responses today). Distinct from
+   * `supportsTools` — that flag governs the local tool runtime (Code,
+   * python sandbox, our DuckDuckGo web_search). This one only enables
+   * the chat composer's Search pill for external models. Local models
+   * keep `supportsTools` only.
+   */
+  supportsBuiltinWebSearch: boolean;
+  /**
+   * Whether the active external provider exposes a server-side
+   * code-execution tool (Anthropic's `code_execution_20250825` on the
+   * Claude 4.x family). Distinct from `supportsTools` for the same
+   * reason as `supportsBuiltinWebSearch`: external providers don't
+   * give us a local tool runtime, but Anthropic dispatches code
+   * execution server-side. Read by both composers' Code pill gate.
+   */
+  supportsBuiltinCodeExecution: boolean;
+  /**
+   * Whether the active external provider exposes a server-side
+   * image-generation tool (OpenAI's Responses-API `image_generation`
+   * today). Gates the chat composer's Images pill. Local models never
+   * receive the tool because their runtime cannot dispatch it.
+   */
+  supportsBuiltinImageGeneration: boolean;
+  /**
+   * Whether the active external provider exposes a server-side
+   * web_fetch tool (Anthropic's `web_fetch_20250910` /
+   * `web_fetch_20260209`). Gates the composer's Fetch pill,
+   * independent of Search.
+   */
+  supportsBuiltinWebFetch: boolean;
   toolsEnabled: boolean;
   codeToolsEnabled: boolean;
+  imageToolsEnabled: boolean;
+  artifactsEnabled: boolean;
+  collapseHtmlArtifacts: boolean;
+  allowArtifactNetworkAccess: boolean;
+  mcpEnabledForChat: boolean;
+  /**
+   * Fetch pill state, independent of `toolsEnabled` (Search). Only
+   * consulted when `providerSupportsBuiltinWebFetch` is true.
+   */
+  webFetchToolsEnabled: boolean;
   toolStatus: string | null;
   generatingStatus: string | null;
   autoHealToolCalls: boolean;
@@ -205,18 +325,27 @@ type ChatRuntimeStore = {
   loadedKvCacheDtype: string | null;
   speculativeType: string | null;
   loadedSpeculativeType: string | null;
+  /** User --spec-draft-n-max override (null = platform default). */
+  specDraftNMax: number | null;
+  loadedSpecDraftNMax: number | null;
+  loadedIsMultimodal: boolean;
   customContextLength: number | null;
   defaultChatTemplate: string | null;
   chatTemplateOverride: string | null;
+  loadedChatTemplateOverride: string | null;
   activeThreadId: string | null;
+  activeProjectId: string | null;
   settingsPanelOpen: boolean;
   pendingAudioBase64: string | null;
   pendingAudioName: string | null;
+  pendingImageEditReference: PendingImageEditReference | null;
   contextUsage: {
     promptTokens: number;
     completionTokens: number;
     totalTokens: number;
     cachedTokens: number;
+    // Anthropic-only; optional so pre-cache-stats persisted entries load.
+    cacheWriteTokens?: number;
   } | null;
   modelLoading: boolean;
   lileMode: boolean;
@@ -225,22 +354,46 @@ type ChatRuntimeStore = {
   setLileMode: (v: boolean) => void;
   setLileBlockOnLastCommit: (v: boolean) => void;
   setLileLastCommit: (v: number | null) => void;
+  activeNativePathToken: string | null;
+  hydratePersistedSettings: () => Promise<void>;
   setModelLoading: (loading: boolean) => void;
   setModelRequiresTrustRemoteCode: (required: boolean) => void;
   setParams: (params: InferenceParams) => void;
+  setCustomPresets: (presets: Preset[]) => void;
+  setActivePreset: (name: string) => void;
+  setActivePresetSource: (source: ChatPresetSource) => void;
   setModels: (models: ChatModelSummary[]) => void;
   setLoras: (loras: ChatLoraSummary[]) => void;
   setThreadRunning: (threadId: string, running: boolean) => void;
+  registerThreadCancel: (threadId: string, cancel: () => void) => void;
+  clearThreadCancel: (threadId: string) => void;
   setAutoTitle: (enabled: boolean) => void;
   setHfToken: (token: string) => void;
   setModelsError: (error: string | null) => void;
   setCheckpoint: (modelId: string, ggufVariant?: string | null) => void;
   setActiveThreadId: (threadId: string | null) => void;
+  setActiveProjectId: (projectId: string | null) => void;
   setSettingsPanelOpen: (open: boolean) => void;
   clearCheckpoint: () => void;
-  setReasoningEnabled: (enabled: boolean) => void;
-  setToolsEnabled: (enabled: boolean) => void;
+  setReasoningEnabled: (
+    enabled: boolean,
+    options?: { persist?: boolean },
+  ) => void;
+  setLastOpenRouterChosenModel: (chosen: string | null) => void;
+  setReasoningStyle: (style: ReasoningStyle) => void;
+  setReasoningEffort: (effort: ReasoningEffort) => void;
+  setPreserveThinking: (value: boolean) => void;
+  setToolsEnabled: (enabled: boolean, options?: { persist?: boolean }) => void;
   setCodeToolsEnabled: (enabled: boolean) => void;
+  setImageToolsEnabled: (enabled: boolean) => void;
+  setArtifactsEnabled: (
+    enabled: boolean,
+    options?: { persist?: boolean },
+  ) => void;
+  setCollapseHtmlArtifacts: (enabled: boolean) => void;
+  setAllowArtifactNetworkAccess: (enabled: boolean) => void;
+  setMcpEnabledForChat: (enabled: boolean) => void;
+  setWebFetchToolsEnabled: (enabled: boolean) => void;
   setToolStatus: (status: string | null) => void;
   setGeneratingStatus: (status: string | null) => void;
   setAutoHealToolCalls: (enabled: boolean) => void;
@@ -248,23 +401,223 @@ type ChatRuntimeStore = {
   setToolCallTimeout: (value: number) => void;
   setKvCacheDtype: (dtype: string | null) => void;
   setSpeculativeType: (type: string | null) => void;
+  setSpecDraftNMax: (value: number | null) => void;
   setCustomContextLength: (v: number | null) => void;
   setChatTemplateOverride: (template: string | null) => void;
   setPendingAudio: (base64: string, name: string) => void;
   clearPendingAudio: () => void;
+  setPendingImageEditReference: (
+    reference: PendingImageEditReference | null,
+  ) => void;
+  clearPendingImageEditReference: () => void;
   setContextUsage: (usage: ChatRuntimeStore["contextUsage"]) => void;
-  // Upstream-compat shim: chat-page.tsx calls this on mount to rehydrate
-  // any localStorage-persisted toggles. HT's store loads each value at
-  // create-time via loadBool/loadString, so there's nothing to do at runtime.
-  hydratePersistedSettings: () => void;
 };
 
-export const useChatRuntimeStore = create<ChatRuntimeStore>((set) => ({
-  params: loadInferenceParams(),
+type PersistedChatSettings = Awaited<
+  ReturnType<typeof loadChatSettingsWithLegacyImport>
+>;
+type PersistedInferenceParams = NonNullable<
+  PersistedChatSettings["inferenceParams"]
+>;
+type PersistedInferenceParamKey = keyof PersistedInferenceParams;
+type ScalarSettingKey =
+  | "autoTitle"
+  | "reasoningEffort"
+  | "preserveThinking"
+  | "autoHealToolCalls"
+  | "maxToolCallsPerMessage"
+  | "toolCallTimeout";
+
+type PresetHydrationVersions = {
+  customPresets: number;
+  activePreset: number;
+  activePresetSource: number;
+};
+
+type SettingsHydrationVersions = {
+  inferenceParams: Record<PersistedInferenceParamKey, number>;
+  scalarSettings: Record<ScalarSettingKey, number>;
+  presets: PresetHydrationVersions;
+};
+
+const PERSISTED_INFERENCE_PARAM_KEYS = [
+  "temperature",
+  "topP",
+  "topK",
+  "minP",
+  "repetitionPenalty",
+  "presencePenalty",
+  "maxSeqLength",
+  "maxTokens",
+  "systemPrompt",
+  "trustRemoteCode",
+  "fastMode",
+] as const satisfies readonly PersistedInferenceParamKey[];
+
+const SCALAR_SETTING_KEYS = [
+  "autoTitle",
+  "reasoningEffort",
+  "preserveThinking",
+  "autoHealToolCalls",
+  "maxToolCallsPerMessage",
+  "toolCallTimeout",
+] as const satisfies readonly ScalarSettingKey[];
+
+const inferenceParamMutationVersions = Object.fromEntries(
+  PERSISTED_INFERENCE_PARAM_KEYS.map((key) => [key, 0]),
+) as Record<PersistedInferenceParamKey, number>;
+const scalarSettingMutationVersions = Object.fromEntries(
+  SCALAR_SETTING_KEYS.map((key) => [key, 0]),
+) as Record<ScalarSettingKey, number>;
+
+function hasKeys(value: object): boolean {
+  return Object.keys(value).length > 0;
+}
+
+function getSettingsHydrationVersions(): SettingsHydrationVersions {
+  return {
+    inferenceParams: { ...inferenceParamMutationVersions },
+    scalarSettings: { ...scalarSettingMutationVersions },
+    presets: {
+      customPresets: customPresetsMutationVersion,
+      activePreset: activePresetMutationVersion,
+      activePresetSource: activePresetSourceMutationVersion,
+    },
+  };
+}
+
+function setInferenceParam(
+  params: InferenceParams,
+  key: PersistedInferenceParamKey,
+  value: PersistedInferenceParams[PersistedInferenceParamKey],
+): void {
+  (params as Record<PersistedInferenceParamKey, unknown>)[key] = value;
+}
+
+function getChangedInferenceParams(
+  nextParams: InferenceParams,
+  currentParams: InferenceParams,
+): PersistedInferenceParams {
+  const changedParams: PersistedInferenceParams = {};
+  for (const key of PERSISTED_INFERENCE_PARAM_KEYS) {
+    const nextValue = nextParams[key];
+    if (Object.is(nextValue, currentParams[key])) {
+      continue;
+    }
+    inferenceParamMutationVersions[key] += 1;
+    if (nextValue !== undefined) {
+      setInferenceParam(changedParams as InferenceParams, key, nextValue);
+    }
+  }
+  return changedParams;
+}
+
+function getHydratedCustomPresets(
+  settings: PersistedChatSettings,
+  state: ChatRuntimeStore,
+): Preset[] {
+  return (
+    settings.customPresets?.map((preset) => ({
+      name: preset.name,
+      params: {
+        ...DEFAULT_INFERENCE_PARAMS,
+        ...preset.params,
+      },
+    })) ?? state.customPresets
+  );
+}
+
+function getHydratedPresetState(
+  settings: PersistedChatSettings,
+  state: ChatRuntimeStore,
+  versions: PresetHydrationVersions,
+): Partial<
+  Pick<
+    ChatRuntimeStore,
+    "customPresets" | "activePreset" | "activePresetSource"
+  >
+> {
+  const nextState: Partial<
+    Pick<
+      ChatRuntimeStore,
+      "customPresets" | "activePreset" | "activePresetSource"
+    >
+  > = {};
+  if (customPresetsMutationVersion === versions.customPresets) {
+    nextState.customPresets = getHydratedCustomPresets(settings, state);
+  }
+  if (activePresetMutationVersion === versions.activePreset) {
+    nextState.activePreset = settings.activePreset ?? state.activePreset;
+  }
+  if (activePresetSourceMutationVersion === versions.activePresetSource) {
+    const activePreset = nextState.activePreset ?? state.activePreset;
+    nextState.activePresetSource =
+      settings.activePresetSource ?? getPresetSource(activePreset);
+  }
+  return nextState;
+}
+
+function getHydratedSettingsState(
+  settings: PersistedChatSettings,
+  state: ChatRuntimeStore,
+  versions: SettingsHydrationVersions,
+): Partial<ChatRuntimeStore> {
+  const nextState: Partial<ChatRuntimeStore> = {};
+  const params = { ...state.params };
+  for (const key of PERSISTED_INFERENCE_PARAM_KEYS) {
+    const value = settings.inferenceParams?.[key];
+    if (
+      value !== undefined &&
+      inferenceParamMutationVersions[key] === versions.inferenceParams[key]
+    ) {
+      setInferenceParam(params, key, value);
+    }
+  }
+  nextState.params = params;
+  for (const key of SCALAR_SETTING_KEYS) {
+    const value = settings[key];
+    if (
+      value !== undefined &&
+      scalarSettingMutationVersions[key] === versions.scalarSettings[key]
+    ) {
+      (nextState as Record<ScalarSettingKey, unknown>)[key] = value;
+    }
+  }
+  return nextState;
+}
+
+function setScalarSettingVersion<K extends ScalarSettingKey>(
+  key: K,
+  value: ChatRuntimeStore[K],
+  currentValue: ChatRuntimeStore[K],
+): void {
+  if (Object.is(value, currentValue)) {
+    return;
+  }
+  scalarSettingMutationVersions[key] += 1;
+  saveSettingsPatch({ [key]: value });
+}
+
+export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
+  settingsHydrated: false,
+  // Hydrate the last external checkpoint into params.checkpoint so the
+  // external picker selection survives a page refresh. Local model
+  // checkpoints are re-derived from the backend in useChatModelRuntime
+  // and intentionally NOT persisted here.
+  params: (() => {
+    const persistedExternal = loadLastExternalCheckpoint();
+    return persistedExternal
+      ? { ...DEFAULT_INFERENCE_PARAMS, checkpoint: persistedExternal }
+      : DEFAULT_INFERENCE_PARAMS;
+  })(),
+  customPresets: [],
+  activePreset: "Default",
+  activePresetSource: getPresetSource("Default"),
   models: [],
   loras: [],
   runningByThreadId: {},
-  autoTitle: loadBool(AUTO_TITLE_KEY, false),
+  cancelByThreadId: {},
+  autoTitle: false,
   hfToken: loadString(HF_TOKEN_KEY, ""),
   modelsError: null,
   activeGgufVariant: null,
@@ -274,56 +627,137 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set) => ({
   modelRequiresTrustRemoteCode: false,
   supportsReasoning: false,
   reasoningAlwaysOn: false,
-  reasoningEnabled: true,
+  reasoningEnabled: loadBool(CHAT_REASONING_ENABLED_KEY, true),
+  reasoningStyle: "enable_thinking",
+  reasoningEffort: "medium",
+  supportsReasoningOff: false,
+  reasoningEffortLevels: ["low", "medium", "high"],
+  lastOpenRouterChosenModel: null,
+  supportsPreserveThinking: false,
+  preserveThinking: false,
   supportsTools: false,
-  toolsEnabled: false,
-  codeToolsEnabled: false,
+  supportsBuiltinWebSearch: false,
+  supportsBuiltinCodeExecution: false,
+  supportsBuiltinImageGeneration: false,
+  supportsBuiltinWebFetch: false,
+  toolsEnabled: loadBool(CHAT_TOOLS_ENABLED_KEY, false),
+  codeToolsEnabled: loadBool(CHAT_CODE_TOOLS_ENABLED_KEY, false),
+  imageToolsEnabled: loadBool(CHAT_IMAGE_TOOLS_ENABLED_KEY, false),
+  artifactsEnabled: loadBool(CHAT_ARTIFACTS_ENABLED_KEY, false),
+  collapseHtmlArtifacts: loadBool(CHAT_COLLAPSE_HTML_ARTIFACTS_KEY, false),
+  allowArtifactNetworkAccess: loadBool(
+    CHAT_ALLOW_ARTIFACT_NETWORK_ACCESS_KEY,
+    false,
+  ),
+  mcpEnabledForChat: loadBool(CHAT_MCP_ENABLED_KEY, false),
+  webFetchToolsEnabled: loadBool(CHAT_WEB_FETCH_TOOLS_ENABLED_KEY, false),
   toolStatus: null,
   generatingStatus: null,
-  autoHealToolCalls: loadBool(AUTO_HEAL_TOOL_CALLS_KEY, true),
-  maxToolCallsPerMessage: loadInt(MAX_TOOL_CALLS_KEY, 25),
-  toolCallTimeout: loadInt(TOOL_CALL_TIMEOUT_KEY, 5),
+  autoHealToolCalls: true,
+  maxToolCallsPerMessage: 25,
+  toolCallTimeout: 5,
   kvCacheDtype: null,
   loadedKvCacheDtype: null,
-  speculativeType: "ngram-mod",
+  speculativeType: "auto",
   loadedSpeculativeType: null,
+  specDraftNMax: null,
+  loadedSpecDraftNMax: null,
+  loadedIsMultimodal: false,
   customContextLength: null,
   defaultChatTemplate: null,
   chatTemplateOverride: null,
+  loadedChatTemplateOverride: null,
   activeThreadId: null,
+  activeProjectId: null,
   settingsPanelOpen: false,
   pendingAudioBase64: null,
   pendingAudioName: null,
+  pendingImageEditReference: null,
   contextUsage: null,
   modelLoading: false,
   lileMode: loadBool(LILE_MODE_KEY, false),
   lileBlockOnLastCommit: loadBool(LILE_BLOCK_KEY, false),
   lileLastCommit: null,
-  setLileMode: (v) =>
-    set(() => {
-      saveBool(LILE_MODE_KEY, v);
-      return { lileMode: v };
-    }),
-  setLileBlockOnLastCommit: (v) =>
-    set(() => {
-      saveBool(LILE_BLOCK_KEY, v);
-      return { lileBlockOnLastCommit: v };
-    }),
+  setLileMode: (v) => set(() => { saveBool(LILE_MODE_KEY, v); return { lileMode: v }; }),
+  setLileBlockOnLastCommit: (v) => set(() => { saveBool(LILE_BLOCK_KEY, v); return { lileBlockOnLastCommit: v }; }),
   setLileLastCommit: (v) => set({ lileLastCommit: v }),
+  activeNativePathToken: null,
+  hydratePersistedSettings: async () => {
+    if (get().settingsHydrated) {
+      return;
+    }
+    if (settingsHydrationPromise) {
+      return settingsHydrationPromise;
+    }
+    settingsHydrationPromise = (async () => {
+      const hydrationVersions = getSettingsHydrationVersions();
+      try {
+        const settings = await loadChatSettingsWithLegacyImport();
+        set((state) => {
+          if (state.settingsHydrated) {
+            return state;
+          }
+          const nextState: Partial<ChatRuntimeStore> = {
+            settingsHydrated: true,
+            ...getHydratedPresetState(
+              settings,
+              state,
+              hydrationVersions.presets,
+            ),
+            ...getHydratedSettingsState(settings, state, hydrationVersions),
+          };
+          return nextState;
+        });
+      } catch {
+        // Hydrate failed: treat as hydrated-with-defaults so future
+        // setParams calls reach saveSettingsPatch (which surfaces its
+        // own toast on real network failure).
+        warnSettingsPersistenceFailure();
+        set({ settingsHydrated: true });
+      } finally {
+        settingsHydrationPromise = null;
+      }
+    })();
+    return settingsHydrationPromise;
+  },
   setModelLoading: (loading) => set({ modelLoading: loading }),
   setModelRequiresTrustRemoteCode: (modelRequiresTrustRemoteCode) =>
     set({ modelRequiresTrustRemoteCode }),
   setParams: (params) =>
-    set(() => {
-      const persisted = saveInferenceParams(params);
-      if (!persisted && !hasShownInferencePersistenceWarning) {
-        hasShownInferencePersistenceWarning = true;
-        toast.warning("Chat settings could not be persisted", {
-          description:
-            "Your changes apply now, but may reset after refresh.",
-        });
+    set((state) => {
+      // Bump version unconditionally so a late hydration response
+      // won't clobber a pre-hydrate user edit; only the HTTP write
+      // is gated on settingsHydrated.
+      const changedParams = getChangedInferenceParams(params, state.params);
+      if (state.settingsHydrated && hasKeys(changedParams)) {
+        saveSettingsPatch({ inferenceParams: changedParams });
       }
-      return { params };
+      // Mirror setCheckpoint: the local model load path can mutate
+      // params.checkpoint via setParams() before setCheckpoint runs,
+      // leaving stale per-turn counters under the new checkpoint.
+      const checkpointChanged = state.params.checkpoint !== params.checkpoint;
+      return {
+        params,
+        ...(checkpointChanged ? { contextUsage: null } : {}),
+      };
+    }),
+  setCustomPresets: (customPresets) =>
+    set(() => {
+      customPresetsMutationVersion += 1;
+      saveSettingsPatch({ customPresets });
+      return { customPresets };
+    }),
+  setActivePreset: (activePreset) =>
+    set(() => {
+      activePresetMutationVersion += 1;
+      saveSettingsPatch({ activePreset });
+      return { activePreset };
+    }),
+  setActivePresetSource: (activePresetSource) =>
+    set(() => {
+      activePresetSourceMutationVersion += 1;
+      saveSettingsPatch({ activePresetSource });
+      return { activePresetSource };
     }),
   setModels: (models) => set({ models }),
   setLoras: (loras) => set({ loras }),
@@ -337,9 +771,22 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set) => ({
       }
       return { runningByThreadId: next };
     }),
+  registerThreadCancel: (threadId, cancel) =>
+    set((state) => {
+      const next = { ...state.cancelByThreadId };
+      next[threadId] = cancel;
+      return { cancelByThreadId: next };
+    }),
+  clearThreadCancel: (threadId) =>
+    set((state) => {
+      if (!(threadId in state.cancelByThreadId)) return state;
+      const next = { ...state.cancelByThreadId };
+      delete next[threadId];
+      return { cancelByThreadId: next };
+    }),
   setAutoTitle: (autoTitle) =>
-    set(() => {
-      saveBool(AUTO_TITLE_KEY, autoTitle);
+    set((state) => {
+      setScalarSettingVersion("autoTitle", autoTitle, state.autoTitle);
       return { autoTitle };
     }),
   setHfToken: (hfToken) =>
@@ -349,70 +796,218 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set) => ({
     }),
   setModelsError: (modelsError) => set({ modelsError }),
   setCheckpoint: (modelId, ggufVariant) =>
-    set((state) => ({
-      params: {
-        ...state.params,
-        checkpoint: modelId,
-      },
-      activeGgufVariant: ggufVariant ?? null,
-    })),
-  setActiveThreadId: (activeThreadId) => set({ activeThreadId, contextUsage: null }),
+    set((state) => {
+      // Persist external selections so they survive a page refresh.
+      // Local model ids are NOT persisted here -- they get re-derived
+      // from the backend's `/api/inference/status.active_model` on
+      // mount, and a stale persisted local id would race against the
+      // freshly-loaded model. See LAST_EXTERNAL_CHECKPOINT_KEY notes.
+      saveLastExternalCheckpoint(isExternalModelId(modelId) ? modelId : null);
+      // Clear stale per-turn usage when the model changes; the relaxed
+      // external-provider render gate would otherwise show old counters
+      // until the next completion overwrites them.
+      const checkpointChanged = state.params.checkpoint !== modelId;
+      // Clamp maxTokens to the new model's cap on switch into an
+      // external model so a value carried over from a prior local
+      // session does not render above the slider's max.
+      let nextMaxTokens = state.params.maxTokens;
+      if (checkpointChanged && isExternalModelId(modelId)) {
+        const parsed = parseExternalModelId(modelId);
+        const provider = parsed
+          ? useExternalProvidersStore
+              .getState()
+              .providers.find((p) => p.id === parsed.providerId)
+          : null;
+        const cap = getExternalMaxOutputTokens(
+          provider?.providerType,
+          parsed?.modelId,
+        );
+        if (nextMaxTokens > cap) {
+          nextMaxTokens = cap;
+        }
+      }
+      return {
+        params: {
+          ...state.params,
+          checkpoint: modelId,
+          maxTokens: nextMaxTokens,
+        },
+        activeGgufVariant: ggufVariant ?? null,
+        ...(checkpointChanged ? { contextUsage: null } : {}),
+      };
+    }),
+  setActiveThreadId: (activeThreadId) =>
+    set({ activeThreadId, contextUsage: null }),
+  setActiveProjectId: (activeProjectId) => set({ activeProjectId }),
   setSettingsPanelOpen: (settingsPanelOpen) => set({ settingsPanelOpen }),
-  clearCheckpoint: () =>
-    set((state) => ({
+  clearCheckpoint: () => {
+    // Mirror setCheckpoint's persistence behavior: dropping the
+    // checkpoint must also clear any stored external selection so
+    // the next refresh doesn't snap back to a model the user
+    // intentionally cleared.
+    saveLastExternalCheckpoint(null);
+    return set((state) => ({
       params: {
         ...state.params,
         checkpoint: "",
       },
       activeGgufVariant: null,
+      activeNativePathToken: null,
       ggufContextLength: null,
       ggufMaxContextLength: null,
       ggufNativeContextLength: null,
       modelRequiresTrustRemoteCode: false,
       contextUsage: null,
       supportsReasoning: false,
+      reasoningAlwaysOn: false,
       reasoningEnabled: true,
+      reasoningStyle: "enable_thinking",
+      supportsReasoningOff: false,
+      reasoningEffortLevels: ["low", "medium", "high"],
+      supportsPreserveThinking: false,
       supportsTools: false,
+      supportsBuiltinWebSearch: false,
+      supportsBuiltinCodeExecution: false,
+      supportsBuiltinImageGeneration: false,
+      supportsBuiltinWebFetch: false,
       toolsEnabled: false,
       codeToolsEnabled: false,
+      imageToolsEnabled: false,
+      artifactsEnabled: false,
+      mcpEnabledForChat: false,
+      webFetchToolsEnabled: false,
       toolStatus: null,
       kvCacheDtype: null,
       loadedKvCacheDtype: null,
-      speculativeType: "ngram-mod",
+      speculativeType: "auto",
       loadedSpeculativeType: null,
+      specDraftNMax: null,
+      loadedSpecDraftNMax: null,
+      loadedIsMultimodal: false,
       customContextLength: null,
       defaultChatTemplate: null,
       chatTemplateOverride: null,
-    })),
-  setReasoningEnabled: (reasoningEnabled) => set({ reasoningEnabled }),
-  setToolsEnabled: (toolsEnabled) => set({ toolsEnabled }),
-  setCodeToolsEnabled: (codeToolsEnabled) => set({ codeToolsEnabled }),
+      loadedChatTemplateOverride: null,
+      pendingImageEditReference: null,
+    }));
+  },
+  setReasoningEnabled: (reasoningEnabled, options) =>
+    set(() => {
+      if (options?.persist !== false) {
+        saveBool(CHAT_REASONING_ENABLED_KEY, reasoningEnabled);
+      }
+      return { reasoningEnabled };
+    }),
+  setLastOpenRouterChosenModel: (lastOpenRouterChosenModel) =>
+    set({ lastOpenRouterChosenModel }),
+  setReasoningStyle: (reasoningStyle) => set({ reasoningStyle }),
+  setReasoningEffort: (reasoningEffort) =>
+    set((state) => {
+      setScalarSettingVersion(
+        "reasoningEffort",
+        reasoningEffort,
+        state.reasoningEffort,
+      );
+      return { reasoningEffort };
+    }),
+  setPreserveThinking: (preserveThinking) =>
+    set((state) => {
+      setScalarSettingVersion(
+        "preserveThinking",
+        preserveThinking,
+        state.preserveThinking,
+      );
+      return { preserveThinking };
+    }),
+  setToolsEnabled: (toolsEnabled, options) =>
+    set(() => {
+      if (options?.persist !== false) {
+        saveBool(CHAT_TOOLS_ENABLED_KEY, toolsEnabled);
+      }
+      return { toolsEnabled };
+    }),
+  setCodeToolsEnabled: (codeToolsEnabled) =>
+    set(() => {
+      saveBool(CHAT_CODE_TOOLS_ENABLED_KEY, codeToolsEnabled);
+      return { codeToolsEnabled };
+    }),
+  setImageToolsEnabled: (imageToolsEnabled) =>
+    set(() => {
+      saveBool(CHAT_IMAGE_TOOLS_ENABLED_KEY, imageToolsEnabled);
+      return { imageToolsEnabled };
+    }),
+  setArtifactsEnabled: (artifactsEnabled, options) =>
+    set(() => {
+      if (options?.persist !== false) {
+        saveBool(CHAT_ARTIFACTS_ENABLED_KEY, artifactsEnabled);
+      }
+      return { artifactsEnabled };
+    }),
+  setCollapseHtmlArtifacts: (collapseHtmlArtifacts) =>
+    set(() => {
+      saveBool(CHAT_COLLAPSE_HTML_ARTIFACTS_KEY, collapseHtmlArtifacts);
+      return { collapseHtmlArtifacts };
+    }),
+  setAllowArtifactNetworkAccess: (allowArtifactNetworkAccess) =>
+    set(() => {
+      saveBool(
+        CHAT_ALLOW_ARTIFACT_NETWORK_ACCESS_KEY,
+        allowArtifactNetworkAccess,
+      );
+      return { allowArtifactNetworkAccess };
+    }),
+  setMcpEnabledForChat: (mcpEnabledForChat) =>
+    set(() => {
+      saveBool(CHAT_MCP_ENABLED_KEY, mcpEnabledForChat);
+      return { mcpEnabledForChat };
+    }),
+  setWebFetchToolsEnabled: (webFetchToolsEnabled) =>
+    set(() => {
+      saveBool(CHAT_WEB_FETCH_TOOLS_ENABLED_KEY, webFetchToolsEnabled);
+      return { webFetchToolsEnabled };
+    }),
   setToolStatus: (toolStatus) => set({ toolStatus }),
   setGeneratingStatus: (generatingStatus) => set({ generatingStatus }),
   setAutoHealToolCalls: (autoHealToolCalls) =>
-    set(() => {
-      saveBool(AUTO_HEAL_TOOL_CALLS_KEY, autoHealToolCalls);
+    set((state) => {
+      setScalarSettingVersion(
+        "autoHealToolCalls",
+        autoHealToolCalls,
+        state.autoHealToolCalls,
+      );
       return { autoHealToolCalls };
     }),
   setMaxToolCallsPerMessage: (maxToolCallsPerMessage) =>
-    set(() => {
-      saveInt(MAX_TOOL_CALLS_KEY, maxToolCallsPerMessage);
+    set((state) => {
+      setScalarSettingVersion(
+        "maxToolCallsPerMessage",
+        maxToolCallsPerMessage,
+        state.maxToolCallsPerMessage,
+      );
       return { maxToolCallsPerMessage };
     }),
   setToolCallTimeout: (toolCallTimeout) =>
-    set(() => {
-      saveInt(TOOL_CALL_TIMEOUT_KEY, toolCallTimeout);
+    set((state) => {
+      setScalarSettingVersion(
+        "toolCallTimeout",
+        toolCallTimeout,
+        state.toolCallTimeout,
+      );
       return { toolCallTimeout };
     }),
   setKvCacheDtype: (kvCacheDtype) => set({ kvCacheDtype }),
   setSpeculativeType: (speculativeType) => set({ speculativeType }),
+  setSpecDraftNMax: (specDraftNMax) => set({ specDraftNMax }),
   setCustomContextLength: (customContextLength) => set({ customContextLength }),
-  setChatTemplateOverride: (chatTemplateOverride) => set({ chatTemplateOverride }),
+  setChatTemplateOverride: (chatTemplateOverride) =>
+    set({ chatTemplateOverride }),
   setPendingAudio: (base64, name) =>
     set({ pendingAudioBase64: base64, pendingAudioName: name }),
   clearPendingAudio: () =>
     set({ pendingAudioBase64: null, pendingAudioName: null }),
+  setPendingImageEditReference: (pendingImageEditReference) =>
+    set({ pendingImageEditReference }),
+  clearPendingImageEditReference: () =>
+    set({ pendingImageEditReference: null }),
   setContextUsage: (contextUsage) => set({ contextUsage }),
-  // HT compat: no-op — store fields are seeded from localStorage at create-time.
-  hydratePersistedSettings: () => undefined,
 }));

--- a/studio/frontend/src/features/export/constants.ts
+++ b/studio/frontend/src/features/export/constants.ts
@@ -74,8 +74,6 @@ export const METHOD_LABELS: Record<TrainingMethod, string> = {
   qlora: "QLoRA",
   lora: "LoRA",
   full: "Full Fine-tune",
-  cpt: "Continued Pretraining",
-  "prompt-baking": "Prompt Baking",
 };
 
 export const GUIDE_STEPS = [


### PR DESCRIPTION
This PR fixes the frontend TypeScript build errors caused by the upstream rebase. The rebase brought in new upstream components (chat-page.tsx, shared-composer.tsx, use-chat-model-runtime.ts) but left the custom ht chat-runtime-store.ts out of sync, causing the CI Wheel and UI tests to fail on all child branches. This PR aligns the store and fixes missing types. Already cherry-picked to PR #63 and PR #64.