### PR TITLE
feat(lile): Implement admission control and backpressure

### DIFF
--- a/lile/config.py
+++ b/lile/config.py
@@ -19,6 +19,7 @@ class ServeConfig:
 
     data_dir: Path = field(default_factory=lambda: Path("./lile_data"))
     max_queue_depth: int = 64
+    max_samples_per_train_call: int = 256
 
     # Budget passed to ``Controller.graceful_shutdown`` on FastAPI shutdown
     # (SIGINT/SIGTERM via uvicorn's default handler). The queue worker keeps

--- a/lile/controller.py
+++ b/lile/controller.py
@@ -19,8 +19,8 @@ from typing import Any
 # oldest entries. OrderedDict gives O(1) insertion, lookup, and eviction.
 _RESPONSE_INDEX_CAP = 4096
 
-from .commit_stream import StepBroadcaster
 from .config import ServeConfig
+from .step_stream import StepBroadcaster
 from .engine.replay import IdleReplayScheduler, ReplayPolicy
 from .engine.train import TrainEngine
 from .logging_backends import LoggerConfig, MetricsLogger, flatten_scalars, get_logger
@@ -436,25 +436,42 @@ class Controller:
         self._reject_if_shutting_down()
         batch_id = new_batch_id()
         samples = spec.get("samples", [])
+        
+        # Enforce batch size limit
+        max_samples = getattr(self.cfg, "max_samples_per_train_call", 256)
+        if len(samples) > max_samples:
+            from .errors import BatchTooLargeError
+            raise BatchTooLargeError(f"batch size {len(samples)} exceeds max_samples_per_train_call={max_samples}")
+
         chunk_size = spec.get("chunk_size", 2)  # small default for 0.6B; caller can bump
+        
+        # Enforce 0.75 depth warning
+        if self.queue._q.qsize() / max(1, self.queue._q.maxsize) > 0.75:
+            log.warning("compute queue depth high: %d/%d", self.queue._q.qsize(), self.queue._q.maxsize)
+            
         tasks = []
         for i in range(0, max(1, len(samples)), chunk_size):
             sub = {
                 **spec,
                 "samples": samples[i:i + chunk_size] if samples else samples,
             }
-            t = await self.queue.submit("train", sub, batch_id=batch_id)
+            t = await self.queue.try_submit("train", sub, batch_id=batch_id)
             tasks.append(t)
             if not samples:
                 break
         # The step_token is the last task's token.
         step_token = tasks[-1].token
-        return {
+        depth = self.queue._q.qsize()
+        cap = max(1, self.queue._q.maxsize)
+        resp = {
             "batch_id": batch_id,
             "step_token": step_token,
             "n_chunks": len(tasks),
-            "queue_depth": self.queue._q.qsize(),
+            "queue_depth": depth,
         }
+        if depth / cap >= 0.9:
+            resp["queue_pressure"] = "high"
+        return resp
 
     @staticmethod
     def feedback_to_batch(

--- a/lile/errors.py
+++ b/lile/errors.py
@@ -29,6 +29,7 @@ ERROR_CODES: frozenset[str] = frozenset({
     "shutdown_dropped",
     "timeout",
     "internal",
+    "batch_too_large",
 })
 
 
@@ -68,9 +69,15 @@ class NotFoundError(LileError):
     retryable = False
 
 
+class BatchTooLargeError(LileError):
+    code = "batch_too_large"
+    status_code = 413
+    retryable = False
+
+
 class QueueFullError(LileError):
     code = "queue_full"
-    status_code = 503
+    status_code = 429
     retryable = True
 
 

--- a/lile/queue.py
+++ b/lile/queue.py
@@ -19,7 +19,7 @@ import uuid
 from dataclasses import dataclass, field
 from typing import Any, Callable
 
-from .errors import ShutdownDroppedError, ShuttingDownError
+from .errors import QueueFullError, ShutdownDroppedError, ShuttingDownError
 
 log = logging.getLogger(__name__)
 
@@ -82,6 +82,13 @@ class ComputeQueue:
         self._last_enqueue_ts = time.monotonic()
         await self._q.put(task)
         return task
+
+    async def try_submit(self, kind: str, payload: Any, batch_id: str = "") -> QueueTask:
+        if self._q.full():
+            raise QueueFullError(
+                f"compute queue depth {self._q.qsize()}/{self._q.maxsize}; retry after backoff"
+            )
+        return await self.submit(kind, payload, batch_id)
 
     # ------------------------------------------------------------------ idleness
     def is_idle_for(self, seconds: float) -> bool:

--- a/lile/server_errors.py
+++ b/lile/server_errors.py
@@ -48,15 +48,21 @@ def _respond(
     code: str,
     message: str,
     retryable: bool,
+    **kwargs: Any,
 ) -> JSONResponse:
     rid = _resolve_request_id()
     body = envelope_payload(
         code=code, message=message, retryable=retryable, request_id=rid,
     )
+    headers = {REQUEST_ID_HEADER: rid}
+    if kwargs.get("retry_after_ms"):
+        body["error"]["retry_after_ms"] = kwargs["retry_after_ms"]
+        # HTTP standard Retry-After is in seconds.
+        headers["Retry-After"] = str(max(1, int(kwargs["retry_after_ms"] / 1000)))
     return JSONResponse(
         status_code=status_code,
         content=body,
-        headers={REQUEST_ID_HEADER: rid},
+        headers=headers,
     )
 
 
@@ -76,11 +82,16 @@ def _format_validation_message(errors: list[dict[str, Any]]) -> str:
 def register_error_handlers(app: FastAPI) -> None:
     @app.exception_handler(LileError)
     async def _lile_error_handler(_req: Request, exc: LileError) -> JSONResponse:
+        kwargs = {}
+        from .errors import QueueFullError
+        if isinstance(exc, QueueFullError):
+            kwargs["retry_after_ms"] = 500
         return _respond(
             status_code=exc.status_code,
             code=exc.code,
             message=str(exc) or exc.code,
             retryable=exc.retryable,
+            **kwargs,
         )
 
     @app.exception_handler(RequestValidationError)

--- a/lile/tests/conftest.py
+++ b/lile/tests/conftest.py
@@ -35,6 +35,7 @@ collect_ignore_glob: list[str] = []
 # Files that can be imported on a torchless runner. Everything else in
 # ``lile/tests/`` will be skipped at collection time when torch is absent.
 _TORCHLESS_OK = {
+    "test_admission.py",
     "test_errors.py",               # lazy lile.errors import inside tests
     "test_error_middleware.py",     # same; also uses FastAPI/TestClient
     "test_eval_harness.py",         # harness smoke — urllib-only

--- a/lile/tests/test_admission.py
+++ b/lile/tests/test_admission.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import asyncio
+import pytest
+
+from lile.queue import ComputeQueue
+from lile.errors import QueueFullError
+
+pytestmark = pytest.mark.cpu_only
+
+async def dummy_handler(task):
+    await asyncio.sleep(0.05)
+    return task.token
+
+def test_try_submit_queue_full() -> None:
+    q = ComputeQueue(max_depth=2)
+
+    async def run():
+        await q.start(dummy_handler)
+        
+        if q._worker_task:
+            q._hard_stop.set()
+            q._stop.set()
+            await q._worker_task
+            
+        q._accepting = True
+        
+        await q.try_submit("train", {"a": 1})
+        await q.try_submit("train", {"a": 2})
+        
+        with pytest.raises(QueueFullError):
+            await q.try_submit("train", {"a": 3})
+
+    asyncio.run(run())

--- a/lile/tests/test_error_middleware.py
+++ b/lile/tests/test_error_middleware.py
@@ -161,12 +161,14 @@ def test_unknown_response_id_becomes_404_envelope():
     assert "r_missing" in err["message"]
 
 
-def test_queue_full_is_retryable_503():
+def test_queue_full_is_retryable_429():
     app = _build_app()
     with TestClient(app) as client:
         r = client.get("/boom-queue-full")
-    assert r.status_code == 503
-    _assert_envelope(r.json(), code="queue_full", retryable=True)
+    assert r.status_code == 429
+    err = _assert_envelope(r.json(), code="queue_full", retryable=True)
+    assert err.get("retry_after_ms") == 500
+    assert r.headers.get("Retry-After") == "1"
 
 
 def test_shutting_down_is_retryable_503():


### PR DESCRIPTION
Resolves #14.

Implement admission control to protect the ComputeQueue from uncontrolled client flood:
- Add `try_submit` to `ComputeQueue` raising `QueueFullError`
- Update `Controller.submit_train` to use `try_submit`
- Enforce `max_samples_per_train_call` (HTTP 413)
- Surface `QueueFullError` as HTTP 429 with `Retry-After` header and 500ms body hint
- Log warning at 0.75 queue capacity
- Add `queue_pressure: high` response hint at 0.9 capacity
- Add tests to verify behavior