### PR TITLE
feat(lile): Implement API authentication

### DIFF
--- a/lile/config.py
+++ b/lile/config.py
@@ -20,6 +20,10 @@ class ServeConfig:
     data_dir: Path = field(default_factory=lambda: Path("./lile_data"))
     max_queue_depth: int = 64
     max_samples_per_train_call: int = 256
+    
+    # API Authentication
+    api_key: str | None = field(default_factory=lambda: __import__('os').environ.get('LILE_API_KEY'))
+    auth_required_routes: list[str] = field(default_factory=lambda: ["/v1/train", "/v1/feedback", "/v1/state/*"])
 
     # Budget passed to ``Controller.graceful_shutdown`` on FastAPI shutdown
     # (SIGINT/SIGTERM via uvicorn's default handler). The queue worker keeps

--- a/lile/errors.py
+++ b/lile/errors.py
@@ -30,6 +30,7 @@ ERROR_CODES: frozenset[str] = frozenset({
     "timeout",
     "internal",
     "batch_too_large",
+    "unauthorized",
 })
 
 
@@ -72,6 +73,12 @@ class NotFoundError(LileError):
 class BatchTooLargeError(LileError):
     code = "batch_too_large"
     status_code = 413
+    retryable = False
+
+
+class UnauthorizedError(LileError):
+    code = "unauthorized"
+    status_code = 401
     retryable = False
 
 

--- a/lile/middleware.py
+++ b/lile/middleware.py
@@ -76,3 +76,39 @@ class RequestIdLogFilter(logging.Filter):
         rid = _REQUEST_ID_CTX.get()
         record.request_id = rid if rid is not None else "-"
         return True
+
+
+class AuthMiddleware(BaseHTTPMiddleware):
+    def __init__(self, app: ASGIApp, api_key: str | None, auth_required_routes: list[str]) -> None:
+        super().__init__(app)
+        self.api_key = api_key
+        self.auth_required_routes = auth_required_routes
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        if self.api_key is None:
+            return await call_next(request)
+
+        path = request.url.path
+        requires_auth = False
+        for route in self.auth_required_routes:
+            if route.endswith("*") and path.startswith(route[:-1]):
+                requires_auth = True
+                break
+            elif path == route:
+                requires_auth = True
+                break
+
+        if not requires_auth:
+            return await call_next(request)
+
+        auth_header = request.headers.get("Authorization")
+        if not auth_header or not auth_header.startswith("Bearer "):
+            from .server_errors import _respond
+            return _respond(status_code=401, code="unauthorized", message="missing or invalid authorization header", retryable=False)
+
+        token = auth_header[7:]
+        if token != self.api_key:
+            from .server_errors import _respond
+            return _respond(status_code=401, code="unauthorized", message="invalid api key", retryable=False)
+
+        return await call_next(request)

--- a/lile/server.py
+++ b/lile/server.py
@@ -21,7 +21,7 @@ from .config import ServeConfig
 from .controller import Controller
 from .errors import NotFoundError
 from .metrics import MetricsMiddleware
-from .middleware import RequestIDMiddleware, current_request_id
+from .middleware import RequestIDMiddleware, AuthMiddleware, current_request_id
 from .server_errors import register_error_handlers
 
 log = logging.getLogger(__name__)
@@ -125,6 +125,7 @@ def create_app(cfg: ServeConfig | None = None) -> FastAPI:
     # the way in, first on the way out. We want MetricsMiddleware to see the
     # final response status, so it goes outside RequestIDMiddleware.
     app.add_middleware(MetricsMiddleware)
+    app.add_middleware(AuthMiddleware, api_key=cfg.api_key, auth_required_routes=cfg.auth_required_routes)
     app.add_middleware(RequestIDMiddleware)
     register_error_handlers(app)
 

--- a/lile/tests/conftest.py
+++ b/lile/tests/conftest.py
@@ -36,6 +36,7 @@ collect_ignore_glob: list[str] = []
 # ``lile/tests/`` will be skipped at collection time when torch is absent.
 _TORCHLESS_OK = {
     "test_admission.py",
+    "test_auth.py",
     "test_errors.py",               # lazy lile.errors import inside tests
     "test_error_middleware.py",     # same; also uses FastAPI/TestClient
     "test_eval_harness.py",         # harness smoke — urllib-only

--- a/lile/tests/test_auth.py
+++ b/lile/tests/test_auth.py
@@ -1,0 +1,59 @@
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from lile.middleware import RequestIDMiddleware, AuthMiddleware
+from lile.server_errors import register_error_handlers
+
+pytestmark = pytest.mark.cpu_only
+
+def _build_app(api_key="secret", routes=["/v1/train", "/v1/state/*"]):
+    app = FastAPI()
+    app.add_middleware(AuthMiddleware, api_key=api_key, auth_required_routes=routes)
+    app.add_middleware(RequestIDMiddleware)
+    register_error_handlers(app)
+
+    @app.get("/health")
+    def health(): return {"ok": True}
+
+    @app.post("/v1/chat/completions")
+    def chat(): return {"ok": True}
+
+    @app.post("/v1/train")
+    def train(): return {"ok": True}
+    
+    @app.get("/v1/state/snapshots")
+    def snaps(): return {"ok": True}
+
+    return app
+
+def test_auth_rejects_no_key():
+    app = _build_app()
+    with TestClient(app) as client:
+        res = client.post("/v1/chat/completions", json={"messages": []})
+        assert res.status_code == 200
+
+        res = client.post("/v1/train", json={"objective": "sft"})
+        assert res.status_code == 401
+        assert res.json()["error"]["code"] == "unauthorized"
+
+def test_auth_accepts_valid_key():
+    app = _build_app()
+    with TestClient(app) as client:
+        res = client.post("/v1/train", json={"objective": "sft"}, headers={"Authorization": "Bearer secret"})
+        assert res.status_code == 200
+
+def test_auth_bypasses_public_routes():
+    app = _build_app()
+    with TestClient(app) as client:
+        res = client.get("/health")
+        assert res.status_code == 200
+        
+        res = client.get("/v1/state/snapshots")
+        assert res.status_code == 401
+
+def test_auth_disabled():
+    app = _build_app(api_key=None)
+    with TestClient(app) as client:
+        res = client.post("/v1/train")
+        assert res.status_code == 200

--- a/studio/backend/routes/lile.py
+++ b/studio/backend/routes/lile.py
@@ -146,7 +146,14 @@ _PROXY_TIMEOUT = httpx.Timeout(connect=5.0, read=None, write=30.0, pool=5.0)
 
 
 def _forward_headers(headers) -> dict:
-    return {k: v for k, v in headers.items() if k.lower() not in _HOP_BY_HOP}
+    forwarded = {k: v for k, v in headers.items() if k.lower() not in _HOP_BY_HOP}
+    
+    # Inject daemon API key if configured and not provided by the client
+    api_key = os.environ.get("LILE_API_KEY")
+    if api_key and "authorization" not in (k.lower() for k in forwarded.keys()):
+        forwarded["Authorization"] = f"Bearer {api_key}"
+        
+    return forwarded
 
 
 async def _proxy_stream(method: str, url: str, headers: dict, body: bytes):


### PR DESCRIPTION
Resolves #15.

Implement API authentication to protect sensitive daemon routes:
- Add `api_key` and `auth_required_routes` to `ServeConfig` (with defaults for training and state endpoints)
- Implement `AuthMiddleware` to reject unauthorized requests with HTTP 401 Unauthorized envelope
- Inject `Authorization` header in Studio proxy when `LILE_API_KEY` is configured in the environment
- Add test coverage for route protection