### PR TITLE
chore(ci): fix two silently-broken backend tests (lile_router stub + get_model_config signature)

### DIFF
--- a/studio/backend/tests/test_desktop_auth.py
+++ b/studio/backend/tests/test_desktop_auth.py
@@ -437,6 +437,7 @@ def test_health_response_reports_desktop_capability_fields(monkeypatch):
         export_router = APIRouter(),
         inference_router = APIRouter(),
         inference_studio_router = APIRouter(),
+        lile_router = APIRouter(),
         mcp_servers_router = APIRouter(),
         models_router = APIRouter(),
         providers_router = APIRouter(),

--- a/studio/backend/tests/test_models_get_model_config_case_resolution.py
+++ b/studio/backend/tests/test_models_get_model_config_case_resolution.py
@@ -68,7 +68,8 @@ def test_get_model_config_resolves_cached_case_before_model_checks(monkeypatch):
     result = asyncio.run(
         models_route.get_model_config(
             model_name = "org/model",
-            hf_token = None,
+            hf_token_query = None,
+            hf_token_header = None,
             current_subject = "test-subject",
         )
     )


### PR DESCRIPTION
## Summary

Two one-line test fixes that have been silently broken on \`ht\` for some time because Backend CI only runs on \`pull_request\` events, not on direct pushes. Surfaced by [PR #63 CI](https://github.com/heiervang-technologies/ht-unsloth/pull/63) and confirmed inherited by [PR #64 CI](https://github.com/heiervang-technologies/ht-unsloth/pull/64). Landing on \`ht\` directly so all future PRs and rebases get the fix automatically without each one having to re-fix it.

## Fixes

### 1. \`test_desktop_auth.py\` — missing \`lile_router\` in router stub

\`test_health_response_reports_desktop_capability_fields\` builds a \`SimpleNamespace\` as a stand-in for the \`routes\` module, listing 12 routers. The stub predates PR #8 (lile addition to studio). After PR #8, \`studio/backend/main.py\` started importing \`lile_router\` from \`routes\`, but the test stub was never updated. Result: \`ImportError\` on all 4 Python versions in Backend CI.

One-line fix: add \`lile_router=APIRouter()\` to the stub.

### 2. \`test_models_get_model_config_case_resolution.py\` — \`get_model_config\` signature drift

The route signature was split from \`hf_token: Optional[str] = Query(None)\` into two parameters (\`hf_token_query\` Query + \`hf_token_header\` Header, aliased \"hf_token\" and \"X-HF-Token\") as part of the [token-leak fix](https://github.com/heiervang-technologies/ht-unsloth/commit/f86a4bbcb). The test that direct-invokes \`get_model_config\` was not updated, so it now fails with:

\`\`\`
TypeError: get_model_config() got an unexpected keyword argument 'hf_token'
\`\`\`

on all 4 Python versions. Function body resolves both new params via \`hf_token = hf_token_header or hf_token_query\`, so passing both as \`None\` preserves the original behavior.

## Why this isn't on PR #63 or #64

Both fixes are already on PR #63 (cherry-picked here from commits \`464250f1c\` and \`e1f921776\`). Landing them on \`ht\` directly is higher leverage because PR #64 (perf-detach-attention) is currently red with the exact same Class A failure pattern, and any future PR will inherit the same red CI until these tests are fixed at the source. Cleaner to fix once on \`ht\` than to ask each PR author to re-fix.

## Test plan
- [x] Both tests PASS locally with \`/tmp/gemma4-smoke/.venv/bin/python -m pytest\` against current \`ht\` HEAD (2.33s).
- [ ] Backend CI Py 3.10/3.11/3.12/3.13 should turn green on this PR.
- [ ] PR #63 and PR #64 Backend CI should turn green after rebase onto post-merge \`ht\`.

## Meta

Recurring pattern: tests that broke when \`ht\` changed signatures silently rot because \`ht\`'s push-CI only runs the lightweight \`Studio Tests\` workflow. The full pull_request CI matrix surfaces them only when a PR opens. Worth considering widening the on-push policy so future signature drift doesn't compound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)