### PR TITLE
fix(detach): warn on auto-enabled attention detach in vision path

### DIFF
--- a/HT-CHANGELOG.md
+++ b/HT-CHANGELOG.md
@@ -10,6 +10,7 @@ Added a new `detach_attention` flag to `get_peft_model` for MLP-only LoRA fine-t
 When enabled (defaults to `"auto"`, activating when only MLP layers are targeted), it skips building the autograd computation graph through attention layers by wrapping them in `torch.no_grad()`.
 This saves ~25-30% of activation memory during training (with FlashAttention) and increases tokens/sec throughput, at zero quality cost (as earlier gradients flow purely via the residual stream).
 Tested across architectures including Llama, Mistral, Qwen2/3, Gemma2, and Granite.
+Both the text (`FastLanguageModel`) and vision (`FastVisionModel`) paths emit a one-time `warning_once` when `"auto"` turns detaching on, so the gradient-approximation trade-off is visible — the vision path is reachable from Studio's MLP-only module selection.
 
 ### Gemma 4 12B "Unified" — Any-to-Any (2026-06-07)
 

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -1407,7 +1407,8 @@ class FastBaseModel:
             attn_modules = {"q_proj", "k_proj", "v_proj", "o_proj"}
             finetune_attention_modules = any(m in target_modules for m in attn_modules)
 
-        if detach_attention == "auto":
+        detach_attention_auto = detach_attention == "auto"
+        if detach_attention_auto:
             detach_attention = not finetune_attention_modules
         elif detach_attention and finetune_attention_modules:
             import warnings
@@ -1570,13 +1571,19 @@ class FastBaseModel:
             m = m.model
             
         if detach_attention:
+            if detach_attention_auto:
+                logger.warning_once(
+                    "Unsloth: MLP-only LoRA detected — detaching attention from the "
+                    "autograd graph to save VRAM/compute. This changes (approximates) "
+                    "gradients to upstream layers. Pass detach_attention=False to disable."
+                )
             _model = model
             while hasattr(_model, "model") and not hasattr(_model, "layers"):
                 _model = _model.model
             if hasattr(_model, "layers"):
                 for layer in _model.layers:
                     layer.self_attn._unsloth_detach_attn = True
-                    
+
         return model
 
     @staticmethod


### PR DESCRIPTION
## What

Mirror the text-path `logger.warning_once` (shipped in #64) onto `FastVisionModel.get_peft_model` (`unsloth/models/vision.py`). When `detach_attention="auto"` turns detaching **on** for MLP-only LoRA, the user now gets a one-time heads-up that gradients to upstream layers become approximate.

## Why

From the #64 review follow-ups: the vision/VLM detach path is **reachable from the Studio UI** (deselecting q/k/v/o in the Target Modules picker → MLP-only → `finetune_attention_modules` recomputes false → auto-detach engages), yet it flipped detaching on **silently**, while the text path warns. This closes that parity gap.

## Scope

- Pure additive: one captured `detach_attention_auto` bool + one `warning_once`. **No behavior change** — the detach decision is identical; only an emitted log line is new.
- Warning text is verbatim-identical to the text path for consistency.
- HT-CHANGELOG note added under the existing detach entry.

## Deliberately *not* included

The second #64 nit — unifying the MLP-only predicate (`is_mlp_only_lora` vs the inline `{q,k,v,o}` check) — is left as a follow-up: it's a behavioral change on the VLM path (matters for non-standard attention naming / MoE-vision) and wants an actual VLM test, not a confident swap.

## Verification

`python -c ast.parse` OK · `ruff check unsloth/models/vision.py` clean · `detach_attention_auto` defined before use.

Not self-merging — leaving the merge call to the maintainer per the test-first cadence.