### PR TITLE
fix(studio): restore recent-thread test selectors on chat sidebar

### DIFF
--- a/HT-CHANGELOG.md
+++ b/HT-CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes in the HT fork (relative to upstream unsloth) are documented
 
 ## Unreleased
 
+### Restore `recent-thread` test selectors on chat sidebar (2026-06-08)
+
+Re-added `data-testid="recent-thread"` + `data-thread-type` + `data-thread-id` on
+`SidebarMenuButton` in `studio/frontend/src/components/app-sidebar.tsx`.
+These three attributes are present on upstream's recent-chat entries and are what
+`tests/studio/playwright_chat_ui.py:1229` locates; they were dropped during the
+2026-06-01 catch-up rebase when the HT-side delete-button block was merged in,
+which silently red-lit the Chat UI Tests job (Studio / Mac Studio / Windows
+Studio UI CI workflows) for ~14 hours across 10 runs. Purely additive — no
+behavior change, just the test-locator parity.
+
 ### Detached Attention Optimization (2026-06-08)
 
 Added a new `detach_attention` flag to `get_peft_model` for MLP-only LoRA fine-tuning.

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -400,6 +400,9 @@ export function AppSidebar() {
                 {chatItems.map((item) => (
                   <SidebarMenuItem key={item.id} className="group/recent-item relative">
                     <SidebarMenuButton
+                      data-testid="recent-thread"
+                      data-thread-type={item.type}
+                      data-thread-id={item.id}
                       isActive={activeThreadId === item.id}
                       className="rounded-none pl-4 pr-7 text-[13px] font-medium text-[#475569] dark:text-[#94a3b8] hover:bg-muted! hover:text-foreground! data-active:bg-[oklch(0.94_0_0)]! data-active:text-foreground! dark:data-active:bg-[oklch(0.3_0_0)]!"
                       onClick={() => {


### PR DESCRIPTION
## Summary

The 2026-06-01 upstream catch-up rebase silently dropped three attributes from `SidebarMenuButton` in `studio/frontend/src/components/app-sidebar.tsx`:

- `data-testid="recent-thread"`
- `data-thread-type={item.type}`
- `data-thread-id={item.id}`

`tests/studio/playwright_chat_ui.py:1229` locates exactly that testid. Without it the Chat UI Tests step has been silently red across **Studio UI CI**, **Mac Studio UI CI**, and **Windows Studio UI CI** since the rebase — confirmed **10/10 fails across 5 different PR branches over ~14 hours** (memory entry tagged it as a Playwright flake; that's wrong — it's a deterministic regression).

## Diff

```diff
 <SidebarMenuItem key={item.id} className="group/recent-item relative">
   <SidebarMenuButton
+    data-testid="recent-thread"
+    data-thread-type={item.type}
+    data-thread-id={item.id}
     isActive={activeThreadId === item.id}
```

Three attributes restored verbatim from upstream (`upstream/main:studio/frontend/src/components/app-sidebar.tsx:563-567`). HT-side delete-button block at 418-428 untouched.

## Scope guarantees

- **Purely additive** — no behavior change, no removals, no behavior-affecting attribute (the test-id is reflected in the rendered DOM but unused by application code; `data-thread-id`/`-type` are likewise readonly data hooks)
- **No new tests** — the upstream test selector that exists in tree (`playwright_chat_ui.py:1229`) is the validation surface
- **HT-CHANGELOG.md** updated under `## Unreleased`

## Verification

- Source: `grep 'data-testid="recent-thread"' upstream/main:app-sidebar.tsx` returns line 565; on ht returns nothing pre-PR, 1 hit post-PR
- Local diff has 3 attribute additions, zero removals (vs the upstream alignment)

## Why draft

Found during a §3 CI-health spare-cycles sweep; opening as draft because (1) the original §3 chore scoping suggested a "dedicated `chore: restore HT-only UI hardening after 2026-06-01 rebase`" PR but this is the **first commit** I've personally proposed against ht as the trimodal agent, and (2) Markus's standing "merge ready PRs" auth is fresh — leaving the flip-to-ready and merge call to him.

Closes the silent-failure surface; doesn't address the OTHER Class B rebase regressions in `tests/studio/test_composer_rtl_bidi_attribute.py`, `test_cancel_id_wiring.py`, `test_studio_text_descender_clipping.py` (noted in PR #63 comments, separate restorations).